### PR TITLE
feat: switch to material design assets

### DIFF
--- a/EasyRFID_API_Project_Guide - NEW.txt
+++ b/EasyRFID_API_Project_Guide - NEW.txt
@@ -840,7 +840,7 @@ def manual_refresh_dev():
     <meta charset="UTF-8">
     <title>RFID Inventory Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.css">
 </head>
 <body>
 
@@ -874,7 +874,7 @@ def manual_refresh_dev():
 </div>
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.js"></script>
 </body>
 </html>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 RFID3/ RFID6(needs update)
+The project now uses the MDB UI Kit (Material Design for Bootstrap) via CDN for responsive layouts. Previous Bootstrap bundles have been removed.
 ├── app/
 │   ├── __init__.py
 │   ├── routes/
@@ -45,12 +46,6 @@ RFID3/ RFID6(needs update)
 │   │   ├── tab4.js
 │   │   ├── tab5.js
 │   │   └── categories.js
-│   ├── lib/
-│   │   ├── htmx/
-│   │   │   └── htmx.min.js
-│   │   └── bootstrap/
-│   │       ├── bootstrap.min.css
-│   │       └── bootstrap.bundle.min.js
 ├── scripts/
 │   ├── migrate_db.sql
 │   ├── update_rental_class_mappings.py
@@ -1439,14 +1434,7 @@ RFID3/ RFID6
 │   │   ├── tab3.js
 │   │   ├── tab4.js
 │   │   ├── tab5.js
-│   │   ├── 
-│   │   └── 
-│   ├── lib/
-│   │   ├── htmx/
-│   │   │   └── htmx.min.js
-│   │   └── bootstrap/
-│   │       ├── bootstrap.min.css
-│   │       └── bootstrap.bundle.min.js
+│   │   └── categories.js
 ├── scripts/
 │   ├── migrate_db.sql
 │   ├── update_rental_class_mappings.py

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,8 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}RFID DASHBOARD{% endblock %}</title>
-    <link rel="stylesheet" href="/static/lib/bootstrap/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" media="all" onload="if(this.media!='all')this.media='all'">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/static/css/common.css">
     {% if request.path == '/tab/1' %}
         <link rel="stylesheet" href="/static/css/tab1.css">
@@ -62,8 +61,7 @@
         {% elif request.path == '/' or request.path == '/home' %}
             <script src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
         {% endif %}
-        <script src="/static/lib/bootstrap/bootstrap.bundle.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.js"></script>
     {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove redundant Bootstrap references and load MDB UI Kit from CDN
- document the transition away from Bootstrap in README and guides

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892d12205f083259cf1b581c281ed93