### PR TITLE
refactor: adopt ES modules for shared utils and tab state

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -44,22 +44,22 @@
         {% block content %}{% endblock %}
     </div>
     {% block scripts %}
-        <script src="/static/js/common.js?cb={{ cache_bust }}"></script>
-        <script src="/static/js/tab.js?cb={{ cache_bust }}"></script>
+        <script type="module" src="/static/js/common.js?cb={{ cache_bust }}"></script>
+        <script type="module" src="/static/js/tab.js?cb={{ cache_bust }}"></script>
         {% if request.path == '/tab/1' %}
-            <script src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/2' %}
-            <script src="/static/js/tab2.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab2.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/3' %}
-            <script src="/static/js/tab3.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab3.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/4' %}
-            <script src="/static/js/tab4.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab4.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/5' %}
-            <script src="/static/js/tab5.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab5.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/categories' %}
-            <script src="/static/js/categories.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/categories.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/' or request.path == '/home' %}
-            <script src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
         {% endif %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.js"></script>
     {% endblock %}

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,3 +1,4 @@
+import { getCachedTabNum } from './state.js';
 console.log('common.js version: 2025-05-29-v24 loaded');
 
 /**
@@ -344,6 +345,15 @@ function applyFilterToTable(table) {
     rowCountDiv.textContent = `Showing ${visibleRows} of ${rows.length} rows`;
 }
 
+// Expose shared helpers for tab modules
+window.showLoading = showLoading;
+window.hideLoading = hideLoading;
+window.collapseSection = collapseSection;
+window.refreshTab = refreshTab;
+window.normalizeCommonName = normalizeCommonName;
+window.renderPaginationControls = renderPaginationControls;
+window.applyFilterToTable = applyFilterToTable;
+
 /**
  * Apply filter to all levels for Tabs 2 and 4
  * Used by: Tabs 2, 4
@@ -351,7 +361,8 @@ function applyFilterToTable(table) {
  */
 function applyFilterToAllLevelsTabs2And4() {
     // Skip filtering for Tab 3 and non-tab pages
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    const tabNum = getCachedTabNum();
+    if (tabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log('Skipping applyFilterToAllLevels for Tab 3 or non-tab page');
         return;
     }
@@ -549,7 +560,8 @@ function applyFilterToAllLevelsTabs2And4() {
  */
 window.applyGlobalFilter = function() {
     // Skip global filter for Tab 3 and non-tab pages (e.g., /categories)
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    const tabNum = getCachedTabNum();
+    if (tabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log('Skipping global filter application for Tab 3 or non-tab page');
         return;
     }
@@ -568,11 +580,11 @@ window.applyGlobalFilter = function() {
     sessionStorage.setItem('globalFilter', JSON.stringify(window.globalFilter));
 
     // Apply filter based on the current tab
-    if (window.cachedTabNum === 1 && typeof applyFilterToAllLevelsTab1 === 'function') {
+    if (tabNum === 1 && typeof applyFilterToAllLevelsTab1 === 'function') {
         applyFilterToAllLevelsTab1();
-    } else if (window.cachedTabNum === 2 || window.cachedTabNum === 4) {
+    } else if (tabNum === 2 || tabNum === 4) {
         applyFilterToAllLevelsTabs2And4();
-    } else if (window.cachedTabNum === 5 && typeof applyFilterToAllLevelsTab5 === 'function') {
+    } else if (tabNum === 5 && typeof applyFilterToAllLevelsTab5 === 'function') {
         applyFilterToAllLevelsTab5();
     }
 };
@@ -837,7 +849,7 @@ async function printTable(level, id, commonName = null, category = null, subcate
         return;
     }
 
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     let contractNumber = '';
@@ -1164,7 +1176,7 @@ function removeTotalItemsInventoryColumn(table, tabNum) {
  */
 async function printFullItemList(category, subcategory, commonName) {
     console.log(`Printing full item list for Category: ${category}, Subcategory: ${subcategory}, Common Name: ${commonName}`);
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     const normalizedCommonName = normalizeCommonName(commonName);

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,3 +1,4 @@
+import { formatDate } from './utils.js';
 // app/static/js/home.js
 // home.js version: 2025-06-27-v4
 console.log('home.js version: 2025-06-27-v4 loaded');

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -1,0 +1,9 @@
+export let cachedTabNum = null;
+
+export function getCachedTabNum() {
+  return cachedTabNum;
+}
+
+export function setCachedTabNum(num) {
+  cachedTabNum = num;
+}

--- a/static/js/tab.js
+++ b/static/js/tab.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum, setCachedTabNum } from './state.js';
 // app/static/js/tab.js
 // tab.js version: 2025-07-08-v21
 console.log(`tab.js version: 2025-07-08-v21 loaded at ${new Date().toISOString()}`);
@@ -104,6 +106,8 @@ function updateExpandableTable(tableId, data, page, perPage, tabNum, identifier)
 /**
  * Initialize the page
  */
+let tabClickHandler;
+
 document.addEventListener('DOMContentLoaded', () => {
     console.log(`tab.js: DOMContentLoaded at ${new Date().toISOString()}`);
     try {
@@ -121,12 +125,12 @@ document.addEventListener('DOMContentLoaded', () => {
             console.warn(`No tab number found in URL, using default tab number 1 at ${new Date().toISOString()}`);
             tabNum = 1;
         }
-        window.cachedTabNum = tabNum;
-        console.log(`Set window.cachedTabNum=${window.cachedTabNum} at ${new Date().toISOString()}`);
+        setCachedTabNum(tabNum);
+        console.log(`Set cachedTabNum=${getCachedTabNum()} at ${new Date().toISOString()}`);
 
         // Remove any existing click listeners to prevent duplicates
-        document.removeEventListener('click', window.tabClickHandler);
-        window.tabClickHandler = (event) => {
+        document.removeEventListener('click', tabClickHandler);
+        tabClickHandler = (event) => {
             console.log(`Click event triggered at ${new Date().toISOString()}`);
             const printBtn = event.target.closest('.print-btn');
             const printFullBtn = event.target.closest('.print-full-btn');
@@ -226,7 +230,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         };
-        document.addEventListener('click', window.tabClickHandler);
+        document.addEventListener('click', tabClickHandler);
     } catch (error) {
         console.error(`Initialization error: ${error} at ${new Date().toISOString()}`);
     }
@@ -243,7 +247,7 @@ async function printTable(level, id, commonName = null, category = null, subcate
         return;
     }
 
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     let contractNumber = '';
@@ -598,7 +602,7 @@ function removeTotalItemsInventoryColumn(table, tabNum) {
  */
 async function printFullItemList(category, subcategory, commonName) {
     console.log(`Printing full item list for Category: ${category}, Subcategory: ${subcategory}, Common Name: ${commonName} at ${new Date().toISOString()}`);
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     const normalizedCommonName = normalizeCommonName(commonName);

--- a/static/js/tab1.js
+++ b/static/js/tab1.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum } from './state.js';
 // app/static/js/tab1.js
 // tab1.js version: 2025-07-10-v7
 console.log('tab1.js version: 2025-07-10-v7 loaded');
@@ -52,12 +54,12 @@ function debounce(func, wait) {
  */
 function applyFilterToAllLevelsTab1() {
     console.log(`applyFilterToAllLevelsTab1: Starting at ${new Date().toISOString()}`);
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    if (getCachedTabNum() === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log(`Skipping applyFilterToAllLevels for Tab 3 or non-tab page at ${new Date().toISOString()}`);
         return;
     }
 
-    if (window.cachedTabNum === 1 || window.cachedTabNum === 5) {
+    if (getCachedTabNum() === 1 || getCachedTabNum() === 5) {
         const categoryTable = document.getElementById('category-table');
         if (!categoryTable) {
             console.warn(`Category table not found, skipping filter application at ${new Date().toISOString()}`);
@@ -601,7 +603,7 @@ async function loadItems(category, subcategory, commonName, targetId, page = 1) 
 
         if (data.items && data.items.length > 0) {
             data.items.forEach(item => {
-                const lastScanned = formatDate ? formatDate(item.last_scanned_date) : item.last_scanned_date || 'N/A';
+                const lastScanned = formatDate(item.last_scanned_date);
                 const currentStatus = item.status || 'N/A';
                 const currentQuality = item.quality || '';
                 const binLocationLower = item.bin_location ? item.bin_location.toLowerCase() : '';
@@ -826,9 +828,9 @@ const debouncedSaveEdit = debounce(async (cell, tagId, field, category, subcateg
 document.addEventListener('DOMContentLoaded', function() {
     console.log(`tab1.js: DOMContentLoaded at ${new Date().toISOString()}`);
     const isTab1 = window.location.pathname.match(/\/tab\/1\b/);
-    console.log(`isTab1: ${isTab1}, window.cachedTabNum: ${window.cachedTabNum}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
+    console.log(`isTab1: ${isTab1}, getCachedTabNum(): ${getCachedTabNum()}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
 
-    if (!isTab1 && window.cachedTabNum !== 1) {
+    if (!isTab1 && getCachedTabNum() !== 1) {
         console.log(`Not Tab 1, skipping at ${new Date().toISOString()}`);
         return;
     }

--- a/static/js/tab2.js
+++ b/static/js/tab2.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum, setCachedTabNum } from './state.js';
 console.log('tab2.js version: 2025-05-29-v10 loaded');
 
 /**
@@ -376,17 +378,17 @@ window.expandItems = function(contractNumber, commonName, targetId, page = 1, ta
 
 // Load global filter from sessionStorage on page load and format timestamps
 document.addEventListener('DOMContentLoaded', function() {
-    // Set window.cachedTabNum
-    if (!window.cachedTabNum) {
+    // Set cached tab number if needed
+    if (!getCachedTabNum()) {
         const pathMatch = window.location.pathname.match(/\/tab\/(\d+)/);
-        window.cachedTabNum = pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null);
-        console.log('tab2.js: Set window.cachedTabNum:', window.cachedTabNum);
+        setCachedTabNum(pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null));
+        console.log('tab2.js: Set cachedTabNum:', getCachedTabNum());
     } else {
-        console.log('tab2.js: window.cachedTabNum already set:', window.cachedTabNum);
+        console.log('tab2.js: cachedTabNum already set:', getCachedTabNum());
     }
 
-    if (window.cachedTabNum !== 2) {
-        console.log(`Tab ${window.cachedTabNum} detected, skipping tab2.js`);
+    if (getCachedTabNum() !== 2) {
+        console.log(`Tab ${getCachedTabNum()} detected, skipping tab2.js`);
         return;
     }
 
@@ -445,7 +447,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (commonName) {
                 console.log(`Expanding items for ${contractNumber}, ${commonName}`);
                 window.expandItems(contractNumber, commonName, targetId, 1, 2);
-            } else if (contractNumber && window.cachedTabNum === 2) {
+            } else if (contractNumber && getCachedTabNum() === 2) {
                 console.log(`Expanding category for ${contractNumber}`);
                 window.expandCategory(category, targetId, contractNumber, 1, 2);
             }

--- a/static/js/tab3.js
+++ b/static/js/tab3.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum } from './state.js';
 // app/static/js/tab3.js
 // tab3.js version: 2025-07-10-v54
 console.log(`tab3.js version: 2025-07-10-v54 loaded at ${new Date().toISOString()}`);
@@ -469,7 +471,7 @@ console.log(`tab3.js version: 2025-07-10-v54 loaded at ${new Date().toISOString(
 
             if (data.items && data.items.length > 0) {
                 data.items.forEach(item => {
-                    const lastScanned = window.formatDate ? window.formatDate(item.date_last_scanned) : item.date_last_scanned || 'N/A';
+                    const lastScanned = formatDate(item.date_last_scanned);
                     const currentStatus = item.status || 'N/A';
                     const currentQuality = item.quality || '';
                     const binLocationLower = item.bin_location ? item.bin_location.toLowerCase() : '';
@@ -1337,7 +1339,7 @@ console.log(`tab3.js version: 2025-07-10-v54 loaded at ${new Date().toISOString(
      */
     document.addEventListener('DOMContentLoaded', () => {
         console.log(`tab3.js: DOMContentLoaded at ${new Date().toISOString()}`);
-        if (window.location.pathname.match(/\/tab\/3\b/) && window.cachedTabNum === 3) {
+        if (window.location.pathname.match(/\/tab\/3\b/) && getCachedTabNum() === 3) {
             console.log(`Initializing Tab 3 at ${new Date().toISOString()}`);
             initializeTab3();
             document.removeEventListener('click', window.tab3ClickHandler);

--- a/static/js/tab4.js
+++ b/static/js/tab4.js
@@ -1,3 +1,4 @@
+import { getCachedTabNum, setCachedTabNum } from './state.js';
 console.log('tab4.js version: 2025-05-29-v7 loaded');
 
 /**
@@ -594,17 +595,17 @@ function refreshCommonNames(contractNumber) {
 
 // Load global filter from sessionStorage on page load and format timestamps
 document.addEventListener('DOMContentLoaded', function() {
-    // Set window.cachedTabNum
-    if (!window.cachedTabNum) {
+    // Set cached tab number if needed
+    if (!getCachedTabNum()) {
         const pathMatch = window.location.pathname.match(/\/tab\/(\d+)/);
-        window.cachedTabNum = pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null);
-        console.log('tab4.js: Set window.cachedTabNum:', window.cachedTabNum);
+        setCachedTabNum(pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null));
+        console.log('tab4.js: Set cachedTabNum:', getCachedTabNum());
     } else {
-        console.log('tab4.js: window.cachedTabNum already set:', window.cachedTabNum);
+        console.log('tab4.js: cachedTabNum already set:', getCachedTabNum());
     }
 
-    if (window.cachedTabNum !== 4) {
-        console.log(`Tab ${window.cachedTabNum} detected, skipping tab4.js`);
+    if (getCachedTabNum() !== 4) {
+        console.log(`Tab ${getCachedTabNum()} detected, skipping tab4.js`);
         return;
     }
 
@@ -657,7 +658,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (commonName) {
                 console.log(`Expanding items for ${contractNumber}, ${commonName}`);
                 window.expandItems(contractNumber, commonName, targetId, 1, 4);
-            } else if (contractNumber && window.cachedTabNum === 4) {
+            } else if (contractNumber && getCachedTabNum() === 4) {
                 console.log(`Expanding category for ${contractNumber}`);
                 window.expandCategory(category, targetId, contractNumber, 1, 4);
             }

--- a/static/js/tab5.js
+++ b/static/js/tab5.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum } from './state.js';
 console.log('tab5.js version: 2025-06-25-v12 loaded');
 
 /**
@@ -11,12 +13,12 @@ console.log('tab5.js version: 2025-06-25-v12 loaded');
 
 function applyFilterToAllLevelsTab5() {
     console.log(`applyFilterToAllLevelsTab5: Starting at ${new Date().toISOString()}`);
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    if (getCachedTabNum() === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log(`Skipping applyFilterToAllLevels for Tab 3 or non-tab page at ${new Date().toISOString()}`);
         return;
     }
 
-    if (window.cachedTabNum === 1 || window.cachedTabNum === 5) {
+    if (getCachedTabNum() === 1 || getCachedTabNum() === 5) {
         const categoryTable = document.getElementById('category-table');
         if (!categoryTable) {
             console.warn(`Category table not found, skipping filter application at ${new Date().toISOString()}`);
@@ -76,7 +78,7 @@ function applyFilterToAllLevelsTab5() {
                                     const itemRows = itemTable.querySelectorAll('tbody tr') || [];
                                     itemRows.forEach(itemRow => {
                                         let showItemRow = true;
-                                        const colOffset = window.cachedTabNum == 5 ? 1 : 0;
+                                        const colOffset = getCachedTabNum() == 5 ? 1 : 0;
                                         const itemCommonNameCell = itemRow.querySelector(`td:nth-child(${2 + colOffset})`);
                                         const itemContractCell = itemRow.querySelector(`td:nth-child(${5 + colOffset})`);
                                         const itemCommonNameValue = itemCommonNameCell ? itemCommonNameCell.textContent.toLowerCase() : '';
@@ -955,9 +957,9 @@ function updateResalePackToSold() {
 document.addEventListener('DOMContentLoaded', function() {
     console.log(`tab5.js: DOMContentLoaded at ${new Date().toISOString()}`);
     const isTab5 = window.location.pathname.match(/\/tab\/5\b/);
-    console.log(`isTab5: ${isTab5}, window.cachedTabNum: ${window.cachedTabNum}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
+    console.log(`isTab5: ${isTab5}, cachedTabNum: ${getCachedTabNum()}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
 
-    if (!isTab5 && window.cachedTabNum !== 5) {
+    if (!isTab5 && getCachedTabNum() !== 5) {
         console.log(`Not Tab 5, skipping at ${new Date().toISOString()}`);
         return;
     }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,24 @@
+export function formatDate(isoDateString) {
+  if (!isoDateString || isoDateString === 'N/A') return 'N/A';
+  try {
+    const date = new Date(isoDateString);
+    if (isNaN(date.getTime())) return 'N/A';
+
+    const days = ['Sun', 'Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat'];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    const dayName = days[date.getDay()];
+    const monthName = months[date.getMonth()];
+    const day = date.getDate();
+    const year = date.getFullYear();
+    let hour = date.getHours();
+    const minute = date.getMinutes().toString().padStart(2, '0');
+    const ampm = hour >= 12 ? 'pm' : 'am';
+    hour = hour % 12 || 12;
+
+    return `${dayName}, ${monthName} ${day} ${year} ${hour}:${minute} ${ampm}`;
+  } catch (error) {
+    console.error('formatDate error:', error.message);
+    return 'N/A';
+  }
+}


### PR DESCRIPTION
## Summary
- Mark tab scripts as ES modules so browser can resolve imports
- Expose common helper functions on `window` for cross-module use

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a370a2308325865a22c94f49e1b0