### PR TITLE
refactor: adopt ES modules for shared utils and tab state

### DIFF
--- a/app/templates/_category_rows.html
+++ b/app/templates/_category_rows.html
@@ -2,7 +2,7 @@
 <tr class="category-row">
     <td>{{ category.category }}</td>
     <td>
-        <select class="subcategory-select form-control" data-category="{{ category.category | urlencode | replace('\'', '\\\'') | replace('\"', '\\\"') }}" onchange="loadCommonNames(this)">
+        <select class="subcategory-select form-control" data-category="{{ category.category | urlencode | replace('\'', '\\\'') | replace('\"', '\\\"') }}" onchange="tab1.loadCommonNames(this)">
             <option value="">Select a subcategory</option>
         </select>
         <div id="loading-subcat-{{ category.cat_id }}" class="loading-indicator" style="display: none;">Loading...</div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -44,22 +44,22 @@
         {% block content %}{% endblock %}
     </div>
     {% block scripts %}
-        <script src="/static/js/common.js?cb={{ cache_bust }}"></script>
-        <script src="/static/js/tab.js?cb={{ cache_bust }}"></script>
+        <script type="module" src="/static/js/common.js?cb={{ cache_bust }}"></script>
+        <script type="module" src="/static/js/tab.js?cb={{ cache_bust }}"></script>
         {% if request.path == '/tab/1' %}
-            <script src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/2' %}
-            <script src="/static/js/tab2.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab2.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/3' %}
-            <script src="/static/js/tab3.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab3.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/4' %}
-            <script src="/static/js/tab4.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab4.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/tab/5' %}
-            <script src="/static/js/tab5.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab5.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/categories' %}
-            <script src="/static/js/categories.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/categories.js?cb={{ cache_bust }}"></script>
         {% elif request.path == '/' or request.path == '/home' %}
-            <script src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
+            <script type="module" src="/static/js/tab1.js?cb={{ cache_bust }}"></script>
         {% endif %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.js"></script>
     {% endblock %}

--- a/app/templates/tab5.html
+++ b/app/templates/tab5.html
@@ -16,7 +16,7 @@
     <div class="card">
         <div class="card-body">
             <div class="btn-group">
-                <button class="btn btn-primary" onclick="updateResalePackToSold()">Update Resale/Pack to Sold</button>
+                <button class="btn btn-primary" onclick="tab5.updateResalePackToSold()">Update Resale/Pack to Sold</button>
                 <a class="btn btn-success" href="{{ url_for('tab5.export_sold_items_csv') }}">Export Sold Items CSV</a>
             </div>
         </div>
@@ -39,7 +39,7 @@
                 <tr class="category-row">
                     <td>{{ category.category }}</td>
                     <td>
-                        <select class="subcategory-select" data-category="{{ category.category }}" onchange="loadCommonNames(this)">
+                        <select class="subcategory-select" data-category="{{ category.category }}" onchange="tab5.loadCommonNames(this)">
                             <option value="">Select a subcategory</option>
                         </select>
                     </td>

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,3 +1,4 @@
+import { getCachedTabNum } from './state.js';
 console.log('common.js version: 2025-05-29-v24 loaded');
 
 /**
@@ -344,6 +345,15 @@ function applyFilterToTable(table) {
     rowCountDiv.textContent = `Showing ${visibleRows} of ${rows.length} rows`;
 }
 
+// Expose shared helpers for tab modules
+window.showLoading = showLoading;
+window.hideLoading = hideLoading;
+window.collapseSection = collapseSection;
+window.refreshTab = refreshTab;
+window.normalizeCommonName = normalizeCommonName;
+window.renderPaginationControls = renderPaginationControls;
+window.applyFilterToTable = applyFilterToTable;
+
 /**
  * Apply filter to all levels for Tabs 2 and 4
  * Used by: Tabs 2, 4
@@ -351,7 +361,8 @@ function applyFilterToTable(table) {
  */
 function applyFilterToAllLevelsTabs2And4() {
     // Skip filtering for Tab 3 and non-tab pages
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    const tabNum = getCachedTabNum();
+    if (tabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log('Skipping applyFilterToAllLevels for Tab 3 or non-tab page');
         return;
     }
@@ -549,7 +560,8 @@ function applyFilterToAllLevelsTabs2And4() {
  */
 window.applyGlobalFilter = function() {
     // Skip global filter for Tab 3 and non-tab pages (e.g., /categories)
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    const tabNum = getCachedTabNum();
+    if (tabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log('Skipping global filter application for Tab 3 or non-tab page');
         return;
     }
@@ -568,11 +580,11 @@ window.applyGlobalFilter = function() {
     sessionStorage.setItem('globalFilter', JSON.stringify(window.globalFilter));
 
     // Apply filter based on the current tab
-    if (window.cachedTabNum === 1 && typeof applyFilterToAllLevelsTab1 === 'function') {
+    if (tabNum === 1 && typeof applyFilterToAllLevelsTab1 === 'function') {
         applyFilterToAllLevelsTab1();
-    } else if (window.cachedTabNum === 2 || window.cachedTabNum === 4) {
+    } else if (tabNum === 2 || tabNum === 4) {
         applyFilterToAllLevelsTabs2And4();
-    } else if (window.cachedTabNum === 5 && typeof applyFilterToAllLevelsTab5 === 'function') {
+    } else if (tabNum === 5 && typeof applyFilterToAllLevelsTab5 === 'function') {
         applyFilterToAllLevelsTab5();
     }
 };
@@ -837,7 +849,7 @@ async function printTable(level, id, commonName = null, category = null, subcate
         return;
     }
 
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     let contractNumber = '';
@@ -1164,7 +1176,7 @@ function removeTotalItemsInventoryColumn(table, tabNum) {
  */
 async function printFullItemList(category, subcategory, commonName) {
     console.log(`Printing full item list for Category: ${category}, Subcategory: ${subcategory}, Common Name: ${commonName}`);
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     const normalizedCommonName = normalizeCommonName(commonName);

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,3 +1,4 @@
+import { formatDate } from './utils.js';
 // app/static/js/home.js
 // home.js version: 2025-06-27-v4
 console.log('home.js version: 2025-06-27-v4 loaded');

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -1,0 +1,9 @@
+export let cachedTabNum = null;
+
+export function getCachedTabNum() {
+  return cachedTabNum;
+}
+
+export function setCachedTabNum(num) {
+  cachedTabNum = num;
+}

--- a/static/js/tab.js
+++ b/static/js/tab.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum, setCachedTabNum } from './state.js';
 // app/static/js/tab.js
 // tab.js version: 2025-07-08-v21
 console.log(`tab.js version: 2025-07-08-v21 loaded at ${new Date().toISOString()}`);
@@ -104,6 +106,8 @@ function updateExpandableTable(tableId, data, page, perPage, tabNum, identifier)
 /**
  * Initialize the page
  */
+let tabClickHandler;
+
 document.addEventListener('DOMContentLoaded', () => {
     console.log(`tab.js: DOMContentLoaded at ${new Date().toISOString()}`);
     try {
@@ -121,12 +125,12 @@ document.addEventListener('DOMContentLoaded', () => {
             console.warn(`No tab number found in URL, using default tab number 1 at ${new Date().toISOString()}`);
             tabNum = 1;
         }
-        window.cachedTabNum = tabNum;
-        console.log(`Set window.cachedTabNum=${window.cachedTabNum} at ${new Date().toISOString()}`);
+        setCachedTabNum(tabNum);
+        console.log(`Set cachedTabNum=${getCachedTabNum()} at ${new Date().toISOString()}`);
 
         // Remove any existing click listeners to prevent duplicates
-        document.removeEventListener('click', window.tabClickHandler);
-        window.tabClickHandler = (event) => {
+        document.removeEventListener('click', tabClickHandler);
+        tabClickHandler = (event) => {
             console.log(`Click event triggered at ${new Date().toISOString()}`);
             const printBtn = event.target.closest('.print-btn');
             const printFullBtn = event.target.closest('.print-full-btn');
@@ -226,7 +230,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         };
-        document.addEventListener('click', window.tabClickHandler);
+        document.addEventListener('click', tabClickHandler);
     } catch (error) {
         console.error(`Initialization error: ${error} at ${new Date().toISOString()}`);
     }
@@ -243,7 +247,7 @@ async function printTable(level, id, commonName = null, category = null, subcate
         return;
     }
 
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     let contractNumber = '';
@@ -598,7 +602,7 @@ function removeTotalItemsInventoryColumn(table, tabNum) {
  */
 async function printFullItemList(category, subcategory, commonName) {
     console.log(`Printing full item list for Category: ${category}, Subcategory: ${subcategory}, Common Name: ${commonName} at ${new Date().toISOString()}`);
-    const tabNum = window.cachedTabNum || 1;
+    const tabNum = getCachedTabNum() || 1;
     const tabName = tabNum == 2 ? 'Open Contracts' : tabNum == 4 ? 'Laundry Contracts' : tabNum == 5 ? 'Resale/Rental Packs' : tabNum == 3 ? 'Service' : `Tab ${tabNum}`;
 
     const normalizedCommonName = normalizeCommonName(commonName);

--- a/static/js/tab1.js
+++ b/static/js/tab1.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum } from './state.js';
 // app/static/js/tab1.js
 // tab1.js version: 2025-07-10-v7
 console.log('tab1.js version: 2025-07-10-v7 loaded');
@@ -52,12 +54,12 @@ function debounce(func, wait) {
  */
 function applyFilterToAllLevelsTab1() {
     console.log(`applyFilterToAllLevelsTab1: Starting at ${new Date().toISOString()}`);
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    if (getCachedTabNum() === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log(`Skipping applyFilterToAllLevels for Tab 3 or non-tab page at ${new Date().toISOString()}`);
         return;
     }
 
-    if (window.cachedTabNum === 1 || window.cachedTabNum === 5) {
+    if (getCachedTabNum() === 1 || getCachedTabNum() === 5) {
         const categoryTable = document.getElementById('category-table');
         if (!categoryTable) {
             console.warn(`Category table not found, skipping filter application at ${new Date().toISOString()}`);
@@ -601,7 +603,7 @@ async function loadItems(category, subcategory, commonName, targetId, page = 1) 
 
         if (data.items && data.items.length > 0) {
             data.items.forEach(item => {
-                const lastScanned = formatDate ? formatDate(item.last_scanned_date) : item.last_scanned_date || 'N/A';
+                const lastScanned = formatDate(item.last_scanned_date);
                 const currentStatus = item.status || 'N/A';
                 const currentQuality = item.quality || '';
                 const binLocationLower = item.bin_location ? item.bin_location.toLowerCase() : '';
@@ -826,9 +828,9 @@ const debouncedSaveEdit = debounce(async (cell, tagId, field, category, subcateg
 document.addEventListener('DOMContentLoaded', function() {
     console.log(`tab1.js: DOMContentLoaded at ${new Date().toISOString()}`);
     const isTab1 = window.location.pathname.match(/\/tab\/1\b/);
-    console.log(`isTab1: ${isTab1}, window.cachedTabNum: ${window.cachedTabNum}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
+    console.log(`isTab1: ${isTab1}, getCachedTabNum(): ${getCachedTabNum()}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
 
-    if (!isTab1 && window.cachedTabNum !== 1) {
+    if (!isTab1 && getCachedTabNum() !== 1) {
         console.log(`Not Tab 1, skipping at ${new Date().toISOString()}`);
         return;
     }
@@ -1081,3 +1083,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 });
+
+if (!window.tab1) {
+    window.tab1 = {};
+}
+window.tab1.loadCommonNames = loadCommonNames;

--- a/static/js/tab2.js
+++ b/static/js/tab2.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum, setCachedTabNum } from './state.js';
 console.log('tab2.js version: 2025-05-29-v10 loaded');
 
 /**
@@ -376,17 +378,17 @@ window.expandItems = function(contractNumber, commonName, targetId, page = 1, ta
 
 // Load global filter from sessionStorage on page load and format timestamps
 document.addEventListener('DOMContentLoaded', function() {
-    // Set window.cachedTabNum
-    if (!window.cachedTabNum) {
+    // Set cached tab number if needed
+    if (!getCachedTabNum()) {
         const pathMatch = window.location.pathname.match(/\/tab\/(\d+)/);
-        window.cachedTabNum = pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null);
-        console.log('tab2.js: Set window.cachedTabNum:', window.cachedTabNum);
+        setCachedTabNum(pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null));
+        console.log('tab2.js: Set cachedTabNum:', getCachedTabNum());
     } else {
-        console.log('tab2.js: window.cachedTabNum already set:', window.cachedTabNum);
+        console.log('tab2.js: cachedTabNum already set:', getCachedTabNum());
     }
 
-    if (window.cachedTabNum !== 2) {
-        console.log(`Tab ${window.cachedTabNum} detected, skipping tab2.js`);
+    if (getCachedTabNum() !== 2) {
+        console.log(`Tab ${getCachedTabNum()} detected, skipping tab2.js`);
         return;
     }
 
@@ -445,7 +447,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (commonName) {
                 console.log(`Expanding items for ${contractNumber}, ${commonName}`);
                 window.expandItems(contractNumber, commonName, targetId, 1, 2);
-            } else if (contractNumber && window.cachedTabNum === 2) {
+            } else if (contractNumber && getCachedTabNum() === 2) {
                 console.log(`Expanding category for ${contractNumber}`);
                 window.expandCategory(category, targetId, contractNumber, 1, 2);
             }

--- a/static/js/tab3.js
+++ b/static/js/tab3.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum } from './state.js';
 // app/static/js/tab3.js
 // tab3.js version: 2025-07-10-v54
 console.log(`tab3.js version: 2025-07-10-v54 loaded at ${new Date().toISOString()}`);
@@ -469,7 +471,7 @@ console.log(`tab3.js version: 2025-07-10-v54 loaded at ${new Date().toISOString(
 
             if (data.items && data.items.length > 0) {
                 data.items.forEach(item => {
-                    const lastScanned = window.formatDate ? window.formatDate(item.date_last_scanned) : item.date_last_scanned || 'N/A';
+                    const lastScanned = formatDate(item.date_last_scanned);
                     const currentStatus = item.status || 'N/A';
                     const currentQuality = item.quality || '';
                     const binLocationLower = item.bin_location ? item.bin_location.toLowerCase() : '';
@@ -1337,7 +1339,7 @@ console.log(`tab3.js version: 2025-07-10-v54 loaded at ${new Date().toISOString(
      */
     document.addEventListener('DOMContentLoaded', () => {
         console.log(`tab3.js: DOMContentLoaded at ${new Date().toISOString()}`);
-        if (window.location.pathname.match(/\/tab\/3\b/) && window.cachedTabNum === 3) {
+        if (window.location.pathname.match(/\/tab\/3\b/) && getCachedTabNum() === 3) {
             console.log(`Initializing Tab 3 at ${new Date().toISOString()}`);
             initializeTab3();
             document.removeEventListener('click', window.tab3ClickHandler);

--- a/static/js/tab4.js
+++ b/static/js/tab4.js
@@ -1,3 +1,4 @@
+import { getCachedTabNum, setCachedTabNum } from './state.js';
 console.log('tab4.js version: 2025-05-29-v7 loaded');
 
 /**
@@ -594,17 +595,17 @@ function refreshCommonNames(contractNumber) {
 
 // Load global filter from sessionStorage on page load and format timestamps
 document.addEventListener('DOMContentLoaded', function() {
-    // Set window.cachedTabNum
-    if (!window.cachedTabNum) {
+    // Set cached tab number if needed
+    if (!getCachedTabNum()) {
         const pathMatch = window.location.pathname.match(/\/tab\/(\d+)/);
-        window.cachedTabNum = pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null);
-        console.log('tab4.js: Set window.cachedTabNum:', window.cachedTabNum);
+        setCachedTabNum(pathMatch ? parseInt(pathMatch[1], 10) : (window.location.pathname === '/' ? 1 : null));
+        console.log('tab4.js: Set cachedTabNum:', getCachedTabNum());
     } else {
-        console.log('tab4.js: window.cachedTabNum already set:', window.cachedTabNum);
+        console.log('tab4.js: cachedTabNum already set:', getCachedTabNum());
     }
 
-    if (window.cachedTabNum !== 4) {
-        console.log(`Tab ${window.cachedTabNum} detected, skipping tab4.js`);
+    if (getCachedTabNum() !== 4) {
+        console.log(`Tab ${getCachedTabNum()} detected, skipping tab4.js`);
         return;
     }
 
@@ -657,7 +658,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (commonName) {
                 console.log(`Expanding items for ${contractNumber}, ${commonName}`);
                 window.expandItems(contractNumber, commonName, targetId, 1, 4);
-            } else if (contractNumber && window.cachedTabNum === 4) {
+            } else if (contractNumber && getCachedTabNum() === 4) {
                 console.log(`Expanding category for ${contractNumber}`);
                 window.expandCategory(category, targetId, contractNumber, 1, 4);
             }

--- a/static/js/tab5.js
+++ b/static/js/tab5.js
@@ -1,3 +1,5 @@
+import { formatDate } from './utils.js';
+import { getCachedTabNum } from './state.js';
 console.log('tab5.js version: 2025-06-25-v12 loaded');
 
 /**
@@ -11,12 +13,12 @@ console.log('tab5.js version: 2025-06-25-v12 loaded');
 
 function applyFilterToAllLevelsTab5() {
     console.log(`applyFilterToAllLevelsTab5: Starting at ${new Date().toISOString()}`);
-    if (window.cachedTabNum === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
+    if (getCachedTabNum() === 3 || !window.location.pathname.match(/\/tab\/\d+/)) {
         console.log(`Skipping applyFilterToAllLevels for Tab 3 or non-tab page at ${new Date().toISOString()}`);
         return;
     }
 
-    if (window.cachedTabNum === 1 || window.cachedTabNum === 5) {
+    if (getCachedTabNum() === 1 || getCachedTabNum() === 5) {
         const categoryTable = document.getElementById('category-table');
         if (!categoryTable) {
             console.warn(`Category table not found, skipping filter application at ${new Date().toISOString()}`);
@@ -76,7 +78,7 @@ function applyFilterToAllLevelsTab5() {
                                     const itemRows = itemTable.querySelectorAll('tbody tr') || [];
                                     itemRows.forEach(itemRow => {
                                         let showItemRow = true;
-                                        const colOffset = window.cachedTabNum == 5 ? 1 : 0;
+                                        const colOffset = getCachedTabNum() == 5 ? 1 : 0;
                                         const itemCommonNameCell = itemRow.querySelector(`td:nth-child(${2 + colOffset})`);
                                         const itemContractCell = itemRow.querySelector(`td:nth-child(${5 + colOffset})`);
                                         const itemCommonNameValue = itemCommonNameCell ? itemCommonNameCell.textContent.toLowerCase() : '';
@@ -425,12 +427,12 @@ function loadCommonNames(selectElement, page = 1) {
                     paginationRow.innerHTML = `
                         <td colspan="7">
                             <div class="pagination-controls">
-                                <button class="btn btn-sm btn-secondary" 
-                                        onclick="loadCommonNames(document.querySelector('select[data-category=\"${category}\"]'), ${data.page - 1})" 
+                                <button class="btn btn-sm btn-secondary"
+                                        onclick="tab5.loadCommonNames(document.querySelector('select[data-category=\\\"${category}\\\"]'), ${data.page - 1})"
                                         ${data.page === 1 ? 'disabled' : ''}>Previous</button>
                                 <span>Page ${data.page} of ${totalPages}</span>
-                                <button class="btn btn-sm btn-secondary" 
-                                        onclick="loadCommonNames(document.querySelector('select[data-category=\"${category}\"]'), ${data.page + 1})" 
+                                <button class="btn btn-sm btn-secondary"
+                                        onclick="tab5.loadCommonNames(document.querySelector('select[data-category=\\\"${category}\\\"]'), ${data.page + 1})"
                                         ${data.page === totalPages ? 'disabled' : ''}>Next</button>
                             </div>
                         </td>
@@ -786,8 +788,8 @@ function loadItems(category, subcategory, commonName, targetId, page = 1) {
                         <td>${item.quality || 'N/A'}</td>
                         <td>${item.notes || 'N/A'}</td>
                         <td>
-                            <button class="btn btn-sm btn-primary save-btn" 
-                                    onclick="updateItem('${item.tag_id}', '${key}', '${category}', '${subcategory}', '${item.common_name}', '${targetId}')">Save</button>
+                            <button class="btn btn-sm btn-primary save-btn"
+                                    onclick="tab5.updateItem('${item.tag_id}', '${key}', '${category}', '${subcategory}', '${item.common_name}', '${targetId}')">Save</button>
                         </td>
                     `;
                     tbody.appendChild(row);
@@ -799,12 +801,12 @@ function loadItems(category, subcategory, commonName, targetId, page = 1) {
                     const totalPages = Math.ceil(data.total_items / data.per_page);
                     const escapedCommonName = commonName.replace(/'/g, "\\'").replace(/"/g, '\\"');
                     paginationDiv.innerHTML = `
-                        <button class="btn btn-sm btn-secondary" 
-                                onclick="loadItems('${category}', '${subcategory}', '${escapedCommonName}', '${targetId}', ${data.page - 1})" 
+                        <button class="btn btn-sm btn-secondary"
+                                onclick="tab5.loadItems('${category}', '${subcategory}', '${escapedCommonName}', '${targetId}', ${data.page - 1})"
                                 ${data.page === 1 ? 'disabled' : ''}>Previous</button>
                         <span>Page ${data.page} of ${totalPages}</span>
-                        <button class="btn btn-sm btn-secondary" 
-                                onclick="loadItems('${category}', '${subcategory}', '${escapedCommonName}', '${targetId}', ${data.page + 1})" 
+                        <button class="btn btn-sm btn-secondary"
+                                onclick="tab5.loadItems('${category}', '${subcategory}', '${escapedCommonName}', '${targetId}', ${data.page + 1})"
                                 ${data.page === totalPages ? 'disabled' : ''}>Next</button>
                     `;
                 }
@@ -816,7 +818,7 @@ function loadItems(category, subcategory, commonName, targetId, page = 1) {
                     <h5>Bulk Update All Items</h5>
                     <div class="form-group">
                         <label for="bulk-bin-location-${key}">Bin Location:</label>
-                        <select id="bulk-bin-location-${key}" onchange="updateBulkField('${key}', 'bin_location')">
+                        <select id="bulk-bin-location-${key}" onchange="tab5.updateBulkField('${key}', 'bin_location')">
                             <option value="">Select Bin Location</option>
                             <option value="resale">Resale</option>
                             <option value="sold">Sold</option>
@@ -826,13 +828,13 @@ function loadItems(category, subcategory, commonName, targetId, page = 1) {
                     </div>
                     <div class="form-group">
                         <label for="bulk-status-${key}">Status:</label>
-                        <select id="bulk-status-${key}" onchange="updateBulkField('${key}', 'status')">
+                        <select id="bulk-status-${key}" onchange="tab5.updateBulkField('${key}', 'status')">
                             <option value="">Select Status</option>
                             <option value="Ready to Rent">Ready to Rent</option>
                             <option value="Sold">Sold</option>
                         </select>
                     </div>
-                    <button class="btn btn-primary" onclick="bulkUpdateCommonName('${category}', '${subcategory}', '${targetId}', '${key}')">Update All</button>
+                    <button class="btn btn-primary" onclick="tab5.bulkUpdateCommonName('${category}', '${subcategory}', '${targetId}', '${key}')">Update All</button>
                     <h5 class="mt-3">Bulk Update Selected Items</h5>
                     <div class="form-group">
                         <label for="bulk-item-bin-location-${key}">Bin Location:</label>
@@ -852,7 +854,7 @@ function loadItems(category, subcategory, commonName, targetId, page = 1) {
                             <option value="Sold">Sold</option>
                         </select>
                     </div>
-                    <button class="btn btn-primary" onclick="bulkUpdateSelectedItems('${key}')">Update Selected</button>
+                    <button class="btn btn-primary" onclick="tab5.bulkUpdateSelectedItems('${key}')">Update Selected</button>
                 `;
                 wrapper.appendChild(bulkDiv);
             } else {
@@ -955,9 +957,9 @@ function updateResalePackToSold() {
 document.addEventListener('DOMContentLoaded', function() {
     console.log(`tab5.js: DOMContentLoaded at ${new Date().toISOString()}`);
     const isTab5 = window.location.pathname.match(/\/tab\/5\b/);
-    console.log(`isTab5: ${isTab5}, window.cachedTabNum: ${window.cachedTabNum}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
+    console.log(`isTab5: ${isTab5}, cachedTabNum: ${getCachedTabNum()}, pathname: ${window.location.pathname} at ${new Date().toISOString()}`);
 
-    if (!isTab5 && window.cachedTabNum !== 5) {
+    if (!isTab5 && getCachedTabNum() !== 5) {
         console.log(`Not Tab 5, skipping at ${new Date().toISOString()}`);
         return;
     }
@@ -1098,4 +1100,17 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
     }
+});
+
+if (!window.tab5) {
+    window.tab5 = {};
+}
+Object.assign(window.tab5, {
+    loadCommonNames,
+    updateResalePackToSold,
+    updateItem,
+    loadItems,
+    bulkUpdateCommonName,
+    bulkUpdateSelectedItems,
+    updateBulkField
 });

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,24 @@
+export function formatDate(isoDateString) {
+  if (!isoDateString || isoDateString === 'N/A') return 'N/A';
+  try {
+    const date = new Date(isoDateString);
+    if (isNaN(date.getTime())) return 'N/A';
+
+    const days = ['Sun', 'Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat'];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    const dayName = days[date.getDay()];
+    const monthName = months[date.getMonth()];
+    const day = date.getDate();
+    const year = date.getFullYear();
+    let hour = date.getHours();
+    const minute = date.getMinutes().toString().padStart(2, '0');
+    const ampm = hour >= 12 ? 'pm' : 'am';
+    hour = hour % 12 || 12;
+
+    return `${dayName}, ${monthName} ${day} ${year} ${hour}:${minute} ${ampm}`;
+  } catch (error) {
+    console.error('formatDate error:', error.message);
+    return 'N/A';
+  }
+}


### PR DESCRIPTION
## Summary
- expose tab functionality through `window.tab1` and `window.tab5` namespace objects
- update templates and dynamic markup to call namespaced methods like `loadCommonNames`

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a370a2308325865a22c94f49e1b0