### PR TITLE
Cap API request limit at 200

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,31 @@
+import os
+import logging
+import pytest
+
+# Ensure log directory exists before importing the client module
+os.makedirs('/home/tim/RFID3/logs', exist_ok=True)
+
+from app.services.api_client import APIClient
+
+class DummyAuthResponse:
+    status_code = 200
+    def json(self):
+        return {'result': True, 'access_token': 'token'}
+
+class DummyGetResponse:
+    status_code = 200
+    def json(self):
+        return {'data': [], 'totalcount': 0}
+
+
+def test_limit_capped(monkeypatch, caplog):
+    import requests
+    monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: DummyAuthResponse())
+    monkeypatch.setattr(requests, 'get', lambda *args, **kwargs: DummyGetResponse())
+
+    client = APIClient()
+    params = {'limit': 500}
+    with caplog.at_level(logging.WARNING, logger='api_client'):
+        client._make_request('dummy', params=params)
+    assert params['limit'] == 200
+    assert "exceeds API maximum of 200" in caplog.text


### PR DESCRIPTION
## Summary
- Cap API request `limit` parameter to the API maximum of 200 and log a warning when exceeded
- Document the API-imposed limit in `_make_request`
- Add unit test verifying limit capping and warning behavior

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e0bca9a88325995c8ec54fcf3f09