### PR TITLE
refactor logging configuration

### DIFF
--- a/app/routes/home.py
+++ b/app/routes/home.py
@@ -1,29 +1,19 @@
 # app/routes/home.py
 # home.py version: 2025-07-10-v7
-from flask import Blueprint, render_template, current_app
+from flask import Blueprint, render_template
 from .. import db, cache
 from ..models.db_models import ItemMaster, Transaction, RefreshState
 from sqlalchemy import func
 from time import time
 import logging
-import sys       
 from datetime import datetime
 import os
 import json
+from config import LOG_FILE
+from ..services.logger import get_logger
 
 # Configure logging with process ID
-logger = logging.getLogger(f'home_{os.getpid()}')
-logger.setLevel(logging.INFO)
-logger.handlers = []  # Clear existing handlers
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setLevel(logging.INFO)
-console_handler.setFormatter(formatter)
-logger.addHandler(console_handler)
+logger = get_logger(f'home_{os.getpid()}', level=logging.INFO, log_file=LOG_FILE)
 
 home_bp = Blueprint('home', __name__)
 

--- a/app/services/api_client.py
+++ b/app/services/api_client.py
@@ -3,24 +3,20 @@
 import requests
 import time
 from datetime import datetime, timedelta
-from config import API_USERNAME, API_PASSWORD, LOGIN_URL, INCREMENTAL_FALLBACK_SECONDS
+from config import (
+    API_USERNAME,
+    API_PASSWORD,
+    LOGIN_URL,
+    INCREMENTAL_FALLBACK_SECONDS,
+    LOG_FILE,
+)
 import logging
 from urllib.parse import quote
 from .. import cache
+from .logger import get_logger
 
 # Configure logging
-logger = logging.getLogger('api_client')
-logger.setLevel(logging.INFO)
-logger.handlers = []  # Clear existing handlers
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
-console_handler.setFormatter(formatter)
-logger.addHandler(console_handler)
+logger = get_logger('api_client', level=logging.INFO, log_file=LOG_FILE)
 
 class APIClient:
     def __init__(self):

--- a/app/services/logger.py
+++ b/app/services/logger.py
@@ -1,0 +1,32 @@
+import logging
+import os
+from config import LOG_FILE
+
+_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+def get_logger(name: str, level: int = logging.INFO, log_file: str = LOG_FILE, add_handlers: bool = True) -> logging.Logger:
+    """Return a configured logger with file and console handlers.
+
+    Parameters:
+        name: Logger name.
+        level: Logging level.
+        log_file: Path to the log file.
+        add_handlers: Whether to attach handlers. Useful when the caller
+            wants to rely on existing global handlers.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    if add_handlers and not logger.handlers:
+        log_dir = os.path.dirname(log_file)
+        os.makedirs(log_dir, exist_ok=True)
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(level)
+        file_handler.setFormatter(_formatter)
+        logger.addHandler(file_handler)
+
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(level)
+        console_handler.setFormatter(_formatter)
+        logger.addHandler(console_handler)
+    return logger

--- a/app/services/refresh.py
+++ b/app/services/refresh.py
@@ -6,28 +6,24 @@ from datetime import datetime, timedelta
 from sqlalchemy.exc import SQLAlchemyError, OperationalError
 from sqlalchemy.sql import text
 from .. import db
-from ..models.db_models import ItemMaster, Transaction, SeedRentalClass, RefreshState, UserRentalClassMapping
+from ..models.db_models import (
+    ItemMaster,
+    Transaction,
+    SeedRentalClass,
+    RefreshState,
+    UserRentalClassMapping,
+)
 from ..services.api_client import APIClient
 from flask import Blueprint, jsonify
-from config import INCREMENTAL_LOOKBACK_SECONDS
+from config import INCREMENTAL_LOOKBACK_SECONDS, LOG_FILE
 import time
 import os
 import csv
 import json
+from .logger import get_logger
 
 # Configure logging
-logger = logging.getLogger(f'refresh_{os.getpid()}')
-logger.setLevel(logging.INFO)  # Maintain INFO level to minimize disk I/O
-logger.handlers = []  # Clear existing handlers
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
-console_handler.setFormatter(formatter)
-logger.addHandler(console_handler)
+logger = get_logger(f'refresh_{os.getpid()}', level=logging.INFO, log_file=LOG_FILE)
 
 refresh_bp = Blueprint('refresh', __name__)
 

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -2,30 +2,23 @@
 # scheduler.py version: 2025-06-27-v7
 from apscheduler.schedulers.background import BackgroundScheduler
 from redis import Redis
-from config import REDIS_URL, INCREMENTAL_REFRESH_INTERVAL
+from config import REDIS_URL, INCREMENTAL_REFRESH_INTERVAL, LOG_FILE
 from .. import db, cache
 from .refresh import full_refresh, incremental_refresh
 import logging
-import sys
 import os
 import time
 from sqlalchemy.sql import text
 from datetime import datetime
+from .logger import get_logger
 
 # Configure logging with process ID
-logger = logging.getLogger(f'scheduler_{os.getpid()}')
-logger.setLevel(logging.DEBUG)
-logger.handlers = []  # Clear existing handlers
-if os.getpid() == os.getppid():
-    file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
-    file_handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(logging.DEBUG)
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+logger = get_logger(
+    f'scheduler_{os.getpid()}',
+    level=logging.DEBUG,
+    log_file=LOG_FILE,
+    add_handlers=os.getpid() == os.getppid(),
+)
 
 scheduler = BackgroundScheduler()
 


### PR DESCRIPTION
## Summary
- centralize logging configuration with new `get_logger` helper
- use `LOG_FILE` from config across API client, refresh service, scheduler, and home route

## Testing
- `PYTHONPATH=. pytest -q`
- `python - <<'PY'
from app.services.logger import get_logger
from config import LOG_FILE
import os

logger = get_logger('test_logger', log_file=LOG_FILE)
logger.info('Logging test message')

print('Log file:', LOG_FILE)
print('Exists:', os.path.exists(LOG_FILE))
with open(LOG_FILE) as f:
    print('Last log line:', f.readlines()[-1].strip())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893e1e7c460832582ba3375221f02b7