### PR TITLE
Add indexes for ItemMaster and RFIDTag inventory fields

### DIFF
--- a/app/models/db_models.py
+++ b/app/models/db_models.py
@@ -5,6 +5,11 @@ from datetime import datetime
 
 class ItemMaster(db.Model):
     __tablename__ = 'id_item_master'
+    __table_args__ = (
+        db.Index('ix_item_master_rental_class_num', 'rental_class_num'),
+        db.Index('ix_item_master_status', 'status'),
+        db.Index('ix_item_master_bin_location', 'bin_location'),
+    )
 
     tag_id = db.Column(db.String(255), primary_key=True)
     uuid_accounts_fk = db.Column(db.String(255))
@@ -87,6 +92,11 @@ class Transaction(db.Model):
 
 class RFIDTag(db.Model):
     __tablename__ = 'id_rfidtag'
+    __table_args__ = (
+        db.Index('ix_rfidtag_rental_class_num', 'rental_class_num'),
+        db.Index('ix_rfidtag_status', 'status'),
+        db.Index('ix_rfidtag_bin_location', 'bin_location'),
+    )
 
     tag_id = db.Column(db.String(255), primary_key=True)
     uuid_accounts_fk = db.Column(db.String(255))

--- a/migrations/202407261200_add_indexes.sql
+++ b/migrations/202407261200_add_indexes.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS ix_item_master_rental_class_num ON id_item_master (rental_class_num);
+CREATE INDEX IF NOT EXISTS ix_item_master_status ON id_item_master (status);
+CREATE INDEX IF NOT EXISTS ix_item_master_bin_location ON id_item_master (bin_location);
+CREATE INDEX IF NOT EXISTS ix_rfidtag_rental_class_num ON id_rfidtag (rental_class_num);
+CREATE INDEX IF NOT EXISTS ix_rfidtag_status ON id_rfidtag (status);
+CREATE INDEX IF NOT EXISTS ix_rfidtag_bin_location ON id_rfidtag (bin_location);


### PR DESCRIPTION
## Summary
- define SQLAlchemy indexes on `rental_class_num`, `status`, and `bin_location` for `ItemMaster` and `RFIDTag`
- include migration script to add corresponding indexes in the database

## Testing
- `sqlite3 rfid_inventory.db < migrations/202407261200_add_indexes.sql`
- `sqlite3 rfid_inventory.db "EXPLAIN QUERY PLAN SELECT * FROM id_item_master WHERE rental_class_num='RC1';"`
- `sqlite3 rfid_inventory.db "EXPLAIN QUERY PLAN SELECT * FROM id_item_master WHERE status='Ready';"`
- `sqlite3 rfid_inventory.db "EXPLAIN QUERY PLAN SELECT * FROM id_item_master WHERE bin_location='A1';"`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e30b79548325871a79816389f0ce