### PR TITLE
Add indexes for ItemMaster and RFIDTag inventory fields

### DIFF
--- a/app/models/db_models.py
+++ b/app/models/db_models.py
@@ -5,6 +5,11 @@ from datetime import datetime
 
 class ItemMaster(db.Model):
     __tablename__ = 'id_item_master'
+    __table_args__ = (
+        db.Index('ix_item_master_rental_class_num', 'rental_class_num'),
+        db.Index('ix_item_master_status', 'status'),
+        db.Index('ix_item_master_bin_location', 'bin_location'),
+    )
 
     tag_id = db.Column(db.String(255), primary_key=True)
     uuid_accounts_fk = db.Column(db.String(255))
@@ -87,6 +92,11 @@ class Transaction(db.Model):
 
 class RFIDTag(db.Model):
     __tablename__ = 'id_rfidtag'
+    __table_args__ = (
+        db.Index('ix_rfidtag_rental_class_num', 'rental_class_num'),
+        db.Index('ix_rfidtag_status', 'status'),
+        db.Index('ix_rfidtag_bin_location', 'bin_location'),
+    )
 
     tag_id = db.Column(db.String(255), primary_key=True)
     uuid_accounts_fk = db.Column(db.String(255))

--- a/migrations/202407261200_add_indexes.py
+++ b/migrations/202407261200_add_indexes.py
@@ -1,0 +1,49 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def table_exists(cur, name: str) -> bool:
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,))
+    return cur.fetchone() is not None
+
+
+def create_indexes(db_path: str):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    if table_exists(cur, "id_item_master"):
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_item_master_rental_class_num ON id_item_master (rental_class_num)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_item_master_status ON id_item_master (status)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_item_master_bin_location ON id_item_master (bin_location)"
+        )
+    else:
+        print("Skipping ItemMaster indexes; table id_item_master not found")
+
+    if table_exists(cur, "id_rfidtag"):
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_rfidtag_rental_class_num ON id_rfidtag (rental_class_num)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_rfidtag_status ON id_rfidtag (status)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_rfidtag_bin_location ON id_rfidtag (bin_location)"
+        )
+    else:
+        print("Skipping RFIDTag indexes; table id_rfidtag not found")
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    db_file = sys.argv[1] if len(sys.argv) > 1 else "rfid_inventory.db"
+    if not Path(db_file).exists():
+        print(f"Database '{db_file}' does not exist; creating empty file")
+    create_indexes(db_file)


### PR DESCRIPTION
## Summary
- define SQLAlchemy indexes on `rental_class_num`, `status`, and `bin_location` for `ItemMaster` and `RFIDTag`
- provide Python migration script that safely adds the corresponding indexes if the tables exist

## Testing
- `sqlite3 rfid_inventory.db "CREATE TABLE id_item_master (tag_id TEXT PRIMARY KEY, rental_class_num TEXT, status TEXT, bin_location TEXT); CREATE TABLE id_rfidtag (tag_id TEXT PRIMARY KEY, rental_class_num TEXT, status TEXT, bin_location TEXT);"`
- `python migrations/202407261200_add_indexes.py rfid_inventory.db`
- `sqlite3 rfid_inventory.db "EXPLAIN QUERY PLAN SELECT * FROM id_item_master WHERE rental_class_num='RC1';"`
- `sqlite3 rfid_inventory.db "EXPLAIN QUERY PLAN SELECT * FROM id_item_master WHERE status='Ready';"`
- `sqlite3 rfid_inventory.db "EXPLAIN QUERY PLAN SELECT * FROM id_item_master WHERE bin_location='A1';"`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e30b79548325871a79816389f0ce