### PR TITLE
Document prerequisite SQL step for index migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,22 @@ The project now uses the MDB UI Kit (Material Design for Bootstrap) via CDN for 
 └── rfid_dash_dev.service
 
 
-git pull origin 
+## Database Migration: Create Tables and Indexes
+
+Before running `migrations/202407261200_add_indexes.py`, ensure the database contains the `id_item_master` and `id_rfidtag` tables by applying the SQL migration first:
+
+```bash
+sqlite3 rfid_inventory.db < scripts/migrate_db.sql
+```
+
+Then run the Python migration to add indexes:
+
+```bash
+python migrations/202407261200_add_indexes.py rfid_inventory.db
+```
+
+
+git pull origin
 > /home/tim/RFID3/logs/gunicorn_error.log
 > /home/tim/RFID3/logs/gunicorn_access.log
 > /home/tim/RFID3/logs/app.log


### PR DESCRIPTION
## Summary
- explain that `scripts/migrate_db.sql` must run before `migrations/202407261200_add_indexes.py`
- add sample commands for applying the SQL and Python migrations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6893fb2f31508325a9f8c79641e22949