### PR TITLE
docs: clarify MariaDB setup and ports

### DIFF
--- a/INSTALL_PI.md
+++ b/INSTALL_PI.md
@@ -1,6 +1,6 @@
 # Installing RFID Dashboard on a New Raspberry Pi
 
-These steps install the project under `/home/tim/RFID3`, run it on port **8101**, and configure automatic updates via Tailscale and GitHub Actions.
+These steps install the project under `/home/tim/RFID3`, run Gunicorn on port **8102**, and expose Nginx on port **8101** for the user interface while configuring automatic updates via Tailscale and GitHub Actions.
 
 ## 1. Prepare the Pi
 ```bash
@@ -32,7 +32,8 @@ pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-## 4. Configure database and seed data
+## 4. Configure MariaDB and seed data
+The application uses MariaDB for its database. Run the helper script to install and secure MariaDB, create the database, and load the schema:
 ```bash
 chmod +x scripts/setup_mariadb.sh
 sudo scripts/setup_mariadb.sh
@@ -60,11 +61,11 @@ sudo systemctl enable rfid_dash_dev.service
 sudo systemctl start rfid_dash_dev.service
 ```
 
-The dashboard is now available at `http://<pi-ip>:8101`.
+The dashboard is now available at `http://<pi-ip>:8101` through Nginx, which proxies to Gunicorn on port 8102.
 
 
 ## 7. Optional: Nginx proxy
-If you use Nginx, copy `rfid_dash_dev.conf` to `/etc/nginx/sites-available/` and enable it so Nginx listens on port 8101.
+If you use Nginx, copy `rfid_dash_dev.conf` to `/etc/nginx/sites-available/` and enable it so Nginx listens on port 8101 and forwards traffic to Gunicorn on port 8102.
 
 ## 8. Automatic updates via Tailscale
 

--- a/rfid_dash_dev.conf
+++ b/rfid_dash_dev.conf
@@ -3,7 +3,7 @@ listen 8101;
 server_name ${APP_IP:-192.168.3.110};
 
 location / {
-proxy_pass http://127.0.0.1:8101;
+    proxy_pass http://127.0.0.1:8102;
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/rfid_dash_dev.service
+++ b/rfid_dash_dev.service
@@ -8,7 +8,7 @@ Group=www-data
 WorkingDirectory=/home/tim/RFID3
 Environment="PATH=/home/tim/RFID3/venv/bin:/usr/bin"
 Environment="APP_IP=192.168.3.110"
-ExecStart=/home/tim/RFID3/venv/bin/gunicorn --workers 1 --threads 4 --timeout 600 --bind 0.0.0.0:8101 --error-logfile /home/tim/RFID3/logs/gunicorn_error.log --access-logfile /home/tim/RFID3/logs/gunicorn_access.log run:app
+ExecStart=/home/tim/RFID3/venv/bin/gunicorn --workers 1 --threads 4 --timeout 600 --bind 0.0.0.0:8102 --error-logfile /home/tim/RFID3/logs/gunicorn_error.log --access-logfile /home/tim/RFID3/logs/gunicorn_access.log run:app
 ExecStop=/bin/kill -s KILL $MAINPID
 Restart=always
 KillMode=mixed


### PR DESCRIPTION
## Summary
- switch README from sqlite to MariaDB instructions
- document MariaDB setup in Raspberry Pi install guide
- note Gunicorn runs on port 8102 with Nginx serving the UI on 8101

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement apscheduler==3.10.4)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_689404b8aba08325a544435989b49e78