### PR TITLE
Use configurable refresh intervals

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -2,7 +2,12 @@
 # scheduler.py version: 2025-06-27-v7
 from apscheduler.schedulers.background import BackgroundScheduler
 from redis import Redis
-from config import REDIS_URL, INCREMENTAL_REFRESH_INTERVAL, LOG_FILE
+from config import (
+    REDIS_URL,
+    INCREMENTAL_REFRESH_INTERVAL,
+    FULL_REFRESH_INTERVAL,
+    LOG_FILE,
+)
 from .. import db, cache
 from .refresh import full_refresh, incremental_refresh
 import logging
@@ -93,7 +98,7 @@ def init_scheduler(app):
                 if redis_client.setnx(incremental_lock_key, 1):
                     try:
                         redis_client.expire(incremental_lock_key, lock_timeout)
-                        logger.debug("Starting scheduled incremental refresh")
+                        logger.debug("Starting scheduled incremental refresh (item master + transactions)")
                         incremental_refresh()
                         logger.info("Scheduled incremental refresh completed successfully")
                     except Exception as e:
@@ -106,21 +111,61 @@ def init_scheduler(app):
             else:
                 logger.error("Skipping incremental refresh due to database connection failure")
 
-    # Schedule incremental refresh every 300 seconds
-    logger.debug("Adding incremental refresh job to scheduler")
+    def run_full_refresh():
+        with app.app_context():
+            if redis_client.get(incremental_lock_key):
+                logger.debug("Incremental refresh in progress, skipping full refresh")
+                return
+            if retry_database_connection():
+                if redis_client.setnx(lock_key, 1):
+                    try:
+                        redis_client.expire(lock_key, lock_timeout)
+                        logger.debug("Starting scheduled full refresh (item master, transactions, seed data)")
+                        full_refresh()
+                        logger.info("Scheduled full refresh completed successfully")
+                    except Exception as e:
+                        logger.error(f"Full refresh failed: {str(e)}", exc_info=True)
+                    finally:
+                        redis_client.delete(lock_key)
+                        logger.debug("Released full refresh lock")
+                else:
+                    logger.debug("Full refresh lock exists, skipping refresh")
+            else:
+                logger.error("Skipping full refresh due to database connection failure")
+
+    # Schedule incremental refresh based on INCREMENTAL_REFRESH_INTERVAL
+    logger.debug(
+        f"Adding incremental refresh job to scheduler with interval {INCREMENTAL_REFRESH_INTERVAL} seconds"
+    )
     scheduler.add_job(
         func=run_with_context,
         trigger='interval',
-        seconds=300,  # Increased from 60 to 300 seconds
+        seconds=INCREMENTAL_REFRESH_INTERVAL,
         id='incremental_refresh',
         replace_existing=True,
         coalesce=True,
         max_instances=1
     )
+
+    # Schedule full refresh based on FULL_REFRESH_INTERVAL
+    logger.debug(
+        f"Adding full refresh job to scheduler with interval {FULL_REFRESH_INTERVAL} seconds"
+    )
+    scheduler.add_job(
+        func=run_full_refresh,
+        trigger='interval',
+        seconds=FULL_REFRESH_INTERVAL,
+        id='full_refresh',
+        replace_existing=True,
+        coalesce=True,
+        max_instances=1,
+    )
     try:
         logger.debug("Starting scheduler")
         scheduler.start()
-        logger.info("Background scheduler started for incremental refresh every 300 seconds")
+        logger.info(
+            f"Background scheduler started for incremental refresh (item master + transactions) every {INCREMENTAL_REFRESH_INTERVAL} seconds and full refresh (item master, transactions, seed data) every {FULL_REFRESH_INTERVAL} seconds"
+        )
     except Exception as e:
         logger.error(f"Failed to start scheduler: {str(e)}", exc_info=True)
         raise


### PR DESCRIPTION
## Summary
- schedule incremental refresh using `INCREMENTAL_REFRESH_INTERVAL`
- add full refresh job using `FULL_REFRESH_INTERVAL` with redis locks
- log both refresh intervals when scheduler starts
- clarify which datasets are fetched in incremental vs full refresh

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689423f7fd248325a9dbe88c75c14564