### PR TITLE
Fix hand counted contract listing for laundry tab

### DIFF
--- a/static/js/tab4.js
+++ b/static/js/tab4.js
@@ -522,6 +522,20 @@ function removeHandCountedItem() {
         refreshCommonNames(contractNumber);
     });
 }
+function syncContractOption(contractNumber, totalItems) {
+    const contractDropdown = document.getElementById('hand-counted-contract-number');
+    const option = Array.from(contractDropdown.options).find(opt => opt.value === contractNumber);
+    if (totalItems > 0) {
+        if (!option) {
+            const newOption = document.createElement('option');
+            newOption.value = contractNumber;
+            newOption.textContent = contractNumber;
+            contractDropdown.appendChild(newOption);
+        }
+    } else if (option) {
+        option.remove();
+    }
+}
 
 function addContractToTable(contractNumber) {
     const tbody = document.getElementById('category-rows');
@@ -562,9 +576,21 @@ function updateContractCounts(contractNumber) {
             return response.json();
         })
         .then(data => {
+            const totalItems = data.total_items || 0;
             const currentCountElement = document.getElementById(`items-on-contract-${contractNumber}`);
             if (currentCountElement) {
-                currentCountElement.textContent = data.total_items || 0;
+                currentCountElement.textContent = totalItems;
+            }
+            syncContractOption(contractNumber, totalItems);
+            if (totalItems === 0) {
+                const row = document.querySelector(`#category-rows tr[data-contract-number="${contractNumber}"]`);
+                if (row) {
+                    const nextRow = row.nextElementSibling;
+                    if (nextRow && nextRow.querySelector(`#common-${contractNumber}`)) {
+                        nextRow.remove();
+                    }
+                    row.remove();
+                }
             }
         })
         .catch(error => console.error('Error updating Items on Contract count:', error));


### PR DESCRIPTION
## Summary
- List only L contracts with active items when fetching hand-counted contract options
- Keep hand-counted contract dropdown in sync with item counts, removing empty contracts

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e2f58ea1c8325a8af0bfb9ac816f4