### PR TITLE
Fix hand counted contract listing for laundry tab

### DIFF
--- a/static/js/tab4.js
+++ b/static/js/tab4.js
@@ -523,6 +523,28 @@ function removeHandCountedItem() {
     });
 }
 
+// Expose functions globally for inline event handlers
+window.toggleNewContractInput = toggleNewContractInput;
+window.toggleNewItemInput = toggleNewItemInput;
+window.updateItemDropdown = updateItemDropdown;
+window.addHandCountedItem = addHandCountedItem;
+window.removeHandCountedItem = removeHandCountedItem;
+// Keep the hand-counted contract dropdown in sync with active items
+window.syncContractOption = function(contractNumber, totalItems) {
+    const contractDropdown = document.getElementById('hand-counted-contract-number');
+    const option = Array.from(contractDropdown.options).find(opt => opt.value === contractNumber);
+    if (totalItems > 0) {
+        if (!option) {
+            const newOption = document.createElement('option');
+            newOption.value = contractNumber;
+            newOption.textContent = contractNumber;
+            contractDropdown.appendChild(newOption);
+        }
+    } else if (option) {
+        option.remove();
+    }
+};
+
 function addContractToTable(contractNumber) {
     const tbody = document.getElementById('category-rows');
     const existingRow = tbody.querySelector(`tr[data-contract-number="${contractNumber}"]`);
@@ -562,9 +584,21 @@ function updateContractCounts(contractNumber) {
             return response.json();
         })
         .then(data => {
+            const totalItems = data.total_items || 0;
             const currentCountElement = document.getElementById(`items-on-contract-${contractNumber}`);
             if (currentCountElement) {
-                currentCountElement.textContent = data.total_items || 0;
+                currentCountElement.textContent = totalItems;
+            }
+            window.syncContractOption(contractNumber, totalItems);
+            if (totalItems === 0) {
+                const row = document.querySelector(`#category-rows tr[data-contract-number="${contractNumber}"]`);
+                if (row) {
+                    const nextRow = row.nextElementSibling;
+                    if (nextRow && nextRow.querySelector(`#common-${contractNumber}`)) {
+                        nextRow.remove();
+                    }
+                    row.remove();
+                }
             }
         })
         .catch(error => console.error('Error updating Items on Contract count:', error));


### PR DESCRIPTION
## Summary
- List only L contracts with active items when fetching hand-counted contract options
- Keep hand-counted contract dropdown in sync with item counts, removing empty contracts
- Expose hand-count contract and item actions globally to resolve button click errors
- Avoid duplicate `syncContractOption` declarations so the laundry tab script loads cleanly

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e2f58ea1c8325a8af0bfb9ac816f4