### PR TITLE
refactor: remove hardcoded project paths

### DIFF
--- a/app/routes/categories.py
+++ b/app/routes/categories.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import json
+import config
 from flask import Blueprint, render_template, request, jsonify, current_app
 from .. import db, cache
 from ..models.db_models import RentalClassMapping, UserRentalClassMapping, SeedRentalClass, HandCountedCatalog
@@ -15,7 +16,7 @@ from time import time
 logger = logging.getLogger('categories')
 logger.setLevel(logging.INFO)
 logger.handlers = []
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/routes/common.py
+++ b/app/routes/common.py
@@ -10,12 +10,13 @@ from ..models.db_models import Transaction
 from sqlalchemy import func
 import logging
 import sys
+import config
 
 # Configure logging
 logger = logging.getLogger('common')
 logger.setLevel(logging.INFO)
 logger.handlers = []  # Clear existing handlers
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -6,6 +6,7 @@ import redis
 import requests
 import logging
 import sys
+import config
 
 # Configure logging
 logger = logging.getLogger('health')
@@ -15,7 +16,7 @@ logger.setLevel(logging.INFO)
 logger.handlers = []
 
 # File handler for rfid_dashboard.log
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/routes/inventory_analytics.py
+++ b/app/routes/inventory_analytics.py
@@ -9,6 +9,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime, timedelta
 import logging
 import json
+import os
+import config
 
 # Configure logging for Inventory & Analytics
 logger = logging.getLogger('inventory_analytics')
@@ -18,7 +20,8 @@ logger.setLevel(logging.INFO)
 logger.handlers = []
 
 # File handler for inventory_analytics.log
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/inventory_analytics.log')
+inventory_log_file = os.path.join(config.BASE_DIR, 'logs', 'inventory_analytics.log')
+file_handler = logging.FileHandler(inventory_log_file)
 file_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/routes/tab1.py
+++ b/app/routes/tab1.py
@@ -11,6 +11,7 @@ from time import time
 from urllib.parse import unquote
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+import config
 
 # Configure logging
 logger = logging.getLogger('tab1')
@@ -18,7 +19,7 @@ logger.setLevel(logging.DEBUG)
 logger.handlers = []
 
 # File handler for rfid_dashboard.log
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/routes/tab2.py
+++ b/app/routes/tab2.py
@@ -7,6 +7,7 @@ from time import time
 from datetime import datetime, timedelta, timezone
 import logging
 import sys
+import config
 
 # Configure logging
 logger = logging.getLogger('tab2')
@@ -16,7 +17,7 @@ logger.setLevel(logging.DEBUG)
 logger.handlers = []
 
 # File handler for rfid_dashboard.log
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/routes/tab3.py
+++ b/app/routes/tab3.py
@@ -22,13 +22,14 @@ import re
 import json
 import time
 from urllib.parse import unquote
+import config
 
 # Configure logging for Tab 3
 logger = logging.getLogger('tab3')
 logger.setLevel(logging.INFO)
 logger.handlers = []
 
-tab3_log_file = '/home/tim/RFID3/logs/rfid_dashboard.log'
+tab3_log_file = config.LOG_FILE
 try:
     if not os.path.exists(tab3_log_file):
         open(tab3_log_file, 'a').close()
@@ -58,7 +59,7 @@ limiter = Limiter(
     storage_uri="memory://"
 )
 
-SHARED_DIR = '/home/tim/RFID3/shared'
+SHARED_DIR = os.path.join(config.BASE_DIR, 'shared')
 CSV_FILE_PATH = os.path.join(SHARED_DIR, 'rfid_tags.csv')
 LOCK_FILE_PATH = os.path.join(SHARED_DIR, 'rfid_tags.lock')
 

--- a/app/routes/tab4.py
+++ b/app/routes/tab4.py
@@ -7,6 +7,8 @@ from datetime import datetime
 import logging
 import sys
 import time  # Ensure the time module is imported
+import os
+import config
 
 # Configure logging for Tab 4
 logger = logging.getLogger('tab4')
@@ -16,7 +18,8 @@ logger.setLevel(logging.INFO)
 logger.handlers = []
 
 # File handler for tab4.log
-tab4_file_handler = logging.FileHandler('/home/tim/RFID3/logs/tab4.log')
+tab4_log_file = os.path.join(config.BASE_DIR, 'logs', 'tab4.log')
+tab4_file_handler = logging.FileHandler(tab4_log_file)
 tab4_file_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(message)s')
 tab4_file_handler.setFormatter(formatter)
@@ -29,7 +32,7 @@ console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
 # Also log to the main rfid_dashboard.log
-main_file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+main_file_handler = logging.FileHandler(config.LOG_FILE)
 main_file_handler.setLevel(logging.INFO)
 main_file_handler.setFormatter(formatter)
 logger.addHandler(main_file_handler)
@@ -1137,7 +1140,7 @@ def snapshot_status():
         schedule_info = ScheduledSnapshotService.get_snapshot_schedule_info()
         
         # Try to read last run summary
-        last_run_file = '/home/tim/RFID3/logs/last_snapshot_run.json'
+        last_run_file = os.path.join(config.BASE_DIR, 'logs', 'last_snapshot_run.json')
         last_run_info = None
         
         if os.path.exists(last_run_file):
@@ -1152,9 +1155,9 @@ def snapshot_status():
             'last_run': last_run_info,
             'automation_enabled': True,
             'log_files': {
-                'detailed_log': '/home/tim/RFID3/logs/snapshot_automation.log',
-                'cron_log': '/home/tim/RFID3/logs/snapshot_cron.log',
-                'status_summary': '/home/tim/RFID3/logs/last_snapshot_run.json'
+                'detailed_log': os.path.join(config.BASE_DIR, 'logs', 'snapshot_automation.log'),
+                'cron_log': os.path.join(config.BASE_DIR, 'logs', 'snapshot_cron.log'),
+                'status_summary': os.path.join(config.BASE_DIR, 'logs', 'last_snapshot_run.json')
             }
         })
         

--- a/app/routes/tab5.py
+++ b/app/routes/tab5.py
@@ -17,6 +17,8 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from config import BULK_UPDATE_BATCH_SIZE
 from ..services.scheduler import get_scheduler
 from ..services.mappings_cache import get_cached_mappings
+import os
+import config
 
 # Configure logging
 logger = logging.getLogger('tab5')
@@ -26,14 +28,15 @@ logger.setLevel(logging.DEBUG)
 logger.handlers = []
 
 # File handler for rfid_dashboard.log
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)
 logger.addHandler(file_handler)
 
 # Secondary file handler for debug.log
-debug_handler = logging.FileHandler('/home/tim/RFID3/logs/debug.log')
+debug_log_file = os.path.join(config.BASE_DIR, 'logs', 'debug.log')
+debug_handler = logging.FileHandler(debug_log_file)
 debug_handler.setLevel(logging.DEBUG)
 debug_handler.setFormatter(formatter)
 logger.addHandler(debug_handler)

--- a/app/routes/tabs.py
+++ b/app/routes/tabs.py
@@ -4,12 +4,13 @@ from flask import Blueprint, redirect, url_for, jsonify, current_app, render_tem
 from datetime import datetime
 import logging
 import sys
+import config
 
 # Configure logging
 logger = logging.getLogger('tabs')
 logger.setLevel(logging.INFO)
 logger.handlers = []  # Clear existing handlers
-file_handler = logging.FileHandler('/home/tim/RFID3/logs/rfid_dashboard.log')
+file_handler = logging.FileHandler(config.LOG_FILE)
 file_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 file_handler.setFormatter(formatter)

--- a/app/services/refresh.py
+++ b/app/services/refresh.py
@@ -15,7 +15,7 @@ from ..models.db_models import (
 )
 from ..services.api_client import APIClient
 from flask import Blueprint, jsonify
-from config import INCREMENTAL_LOOKBACK_SECONDS, LOG_FILE
+from config import INCREMENTAL_LOOKBACK_SECONDS, LOG_FILE, BASE_DIR
 import time
 import os
 import csv
@@ -82,7 +82,7 @@ def update_refresh_state(state_type, timestamp):
     finally:
         session.close()
 
-def update_user_mappings(session, csv_file_path='/home/tim/RFID3/seeddata_20250425155406.csv'):
+def update_user_mappings(session, csv_file_path=os.path.join(BASE_DIR, 'seeddata_20250425155406.csv')):
     """Populate user_rental_class_mappings from CSV, preserving existing user mappings.
     
     Creates a temporary table to back up user mappings, merges with CSV data

--- a/rfid_dash_dev.conf
+++ b/rfid_dash_dev.conf
@@ -2,17 +2,19 @@ server {
 listen 8101;
 server_name ${APP_IP:-192.168.3.110};
 
-location / {
-    proxy_pass http://127.0.0.1:8102;
-proxy_set_header Host $host;
-proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Proto $scheme;
-}
+    set $project_dir /opt/RFID3;
 
-location /static {
-alias /home/tim/RFID3/static;
-expires 1d;
-}
+    location / {
+        proxy_pass http://127.0.0.1:8102;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /static {
+        alias $project_dir/static;
+        expires 1d;
+    }
 }
 

--- a/rfid_dash_dev.service
+++ b/rfid_dash_dev.service
@@ -5,10 +5,11 @@ After=network.target mariadb.service
 [Service]
 User=tim
 Group=www-data
-WorkingDirectory=/home/tim/RFID3
-Environment="PATH=/home/tim/RFID3/venv/bin:/usr/bin"
+Environment=PROJECT_DIR=/opt/RFID3
+WorkingDirectory=${PROJECT_DIR}
+Environment="PATH=${PROJECT_DIR}/venv/bin:/usr/bin"
 Environment="APP_IP=192.168.3.110"
-ExecStart=/home/tim/RFID3/venv/bin/gunicorn --workers 1 --threads 4 --timeout 600 --bind 0.0.0.0:8102 --error-logfile /home/tim/RFID3/logs/gunicorn_error.log --access-logfile /home/tim/RFID3/logs/gunicorn_access.log run:app
+ExecStart=${PROJECT_DIR}/venv/bin/gunicorn --workers 1 --threads 4 --timeout 600 --bind 0.0.0.0:8102 --error-logfile ${PROJECT_DIR}/logs/gunicorn_error.log --access-logfile ${PROJECT_DIR}/logs/gunicorn_access.log run:app
 ExecStop=/bin/kill -s KILL $MAINPID
 Restart=always
 KillMode=mixed

--- a/scripts/auto_update.sh
+++ b/scripts/auto_update.sh
@@ -4,7 +4,9 @@
 # Created: 2025-08-25
 
 # Configuration
-INSTALL_DIR="/home/tim/RFID3"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_DIR="$PROJECT_DIR"
 LOG_DIR="$INSTALL_DIR/logs"
 LOG_FILE="$LOG_DIR/auto_update.log"
 SERVICE_NAME="rfid_dash_dev.service"

--- a/scripts/create_weekly_snapshots.py
+++ b/scripts/create_weekly_snapshots.py
@@ -1,4 +1,4 @@
-#!/home/tim/RFID3/venv/bin/python3
+#!/usr/bin/env python3
 """
 Weekly Contract Snapshots Script
 Version: 2025-08-24-v1
@@ -7,15 +7,16 @@ This script creates snapshots of all active contracts for historical preservatio
 Designed to run on Wednesdays and Fridays at 7:00 AM via cron.
 
 Usage:
-    python3 /home/tim/RFID3/scripts/create_weekly_snapshots.py
+    python3 scripts/create_weekly_snapshots.py
 
 Cron entry:
     # Contract snapshots on Wed/Fri at 7 AM
-    0 7 * * 3,5 cd /home/tim/RFID3 && /home/tim/RFID3/venv/bin/python3 scripts/create_weekly_snapshots.py >> logs/snapshot_cron.log 2>&1
+    0 7 * * 3,5 cd /path/to/project && /path/to/project/venv/bin/python3 scripts/create_weekly_snapshots.py >> logs/snapshot_cron.log 2>&1
 """
 
 import sys
 import os
+import config
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from datetime import datetime, timezone
@@ -24,7 +25,7 @@ import logging
 
 def setup_logging():
     """Set up logging for the cron job."""
-    log_file = '/home/tim/RFID3/logs/snapshot_automation.log'
+    log_file = os.path.join(config.BASE_DIR, 'logs', 'snapshot_automation.log')
     
     # Create logs directory if it doesn't exist
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
@@ -89,7 +90,7 @@ def main():
                 logger.error(f"Error during cleanup: {str(e)}")
             
             # Write summary to JSON file for monitoring
-            summary_file = '/home/tim/RFID3/logs/last_snapshot_run.json'
+            summary_file = os.path.join(config.BASE_DIR, 'logs', 'last_snapshot_run.json')
             summary = {
                 'timestamp': datetime.now(timezone.utc).isoformat(),
                 'results': results,
@@ -115,7 +116,7 @@ def main():
                 'error': str(e),
                 'success': False
             }
-            with open('/home/tim/RFID3/logs/last_snapshot_run.json', 'w') as f:
+            with open(os.path.join(config.BASE_DIR, 'logs', 'last_snapshot_run.json'), 'w') as f:
                 json.dump(error_summary, f, indent=2)
         except:
             pass

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -15,10 +15,12 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-INSTALL_DIR="/home/tim/RFID3"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_DIR="$PROJECT_DIR"
 VENV_DIR="$INSTALL_DIR/venv"
 SERVICE_NAME="rfid3"
-BACKUP_DIR="/home/tim/RFID3_backup_$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="${PROJECT_DIR}_backup_$(date +%Y%m%d_%H%M%S)"
 
 echo -e "${BLUE}================================================${NC}"
 echo -e "${BLUE}    RFID3 Easy Installation Script v1.0        ${NC}"
@@ -132,6 +134,9 @@ if [ ! -f "$INSTALL_DIR/config.py" ]; then
 # RFID3 Configuration
 import os
 
+# Base directory
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
 # Database configuration
 DB_CONFIG = {
     'host': 'localhost',
@@ -150,7 +155,7 @@ API_PASSWORD = 'your_api_password'
 LOGIN_URL = 'https://cs.iot.ptshome.com/api/v1/login'
 
 # Logging
-LOG_FILE = '/home/tim/RFID3/logs/rfid3.log'
+LOG_FILE = os.path.join(BASE_DIR, 'logs', 'rfid3.log')
 
 # Application settings
 APP_IP = '0.0.0.0'

--- a/scripts/laundry-auto-finalize.service
+++ b/scripts/laundry-auto-finalize.service
@@ -5,9 +5,10 @@ Wants=laundry-auto-finalize.timer
 [Service]
 Type=oneshot
 User=tim
-WorkingDirectory=/home/tim/RFID3
-Environment=PATH=/home/tim/RFID3/venv/bin:/usr/bin
-ExecStart=/home/tim/RFID3/venv/bin/python /home/tim/RFID3/scripts/auto_finalize_laundry.py
+Environment=PROJECT_DIR=/opt/RFID3
+WorkingDirectory=${PROJECT_DIR}
+Environment=PATH=${PROJECT_DIR}/venv/bin:/usr/bin
+ExecStart=${PROJECT_DIR}/venv/bin/python ${PROJECT_DIR}/scripts/auto_finalize_laundry.py
 StandardOutput=journal
 StandardError=journal
 

--- a/scripts/rfid-auto-update.service
+++ b/scripts/rfid-auto-update.service
@@ -5,7 +5,8 @@ Wants=rfid-auto-update.timer
 [Service]
 Type=oneshot
 User=root
-ExecStart=/home/tim/RFID3/scripts/auto_update.sh
+Environment=PROJECT_DIR=/opt/RFID3
+ExecStart=${PROJECT_DIR}/scripts/auto_update.sh
 StandardOutput=journal
 StandardError=journal
 

--- a/scripts/setup_mariadb.sh
+++ b/scripts/setup_mariadb.sh
@@ -77,12 +77,12 @@ sudo usermod -aG mysql tim
 
 # Create logs and backup directories for app
 echo "Creating application directories..."
-sudo mkdir -p /home/tim/RFID3/logs
-sudo mkdir -p /home/tim/RFID3/backups
-sudo chown -R tim:tim /home/tim/RFID3/logs
-sudo chown -R tim:tim /home/tim/RFID3/backups
-sudo chmod 750 /home/tim/RFID3/logs
-sudo chmod 750 /home/tim/RFID3/backups
+sudo mkdir -p "$PROJECT_DIR/logs"
+sudo mkdir -p "$PROJECT_DIR/backups"
+sudo chown -R tim:tim "$PROJECT_DIR/logs"
+sudo chown -R tim:tim "$PROJECT_DIR/backups"
+sudo chmod 750 "$PROJECT_DIR/logs"
+sudo chmod 750 "$PROJECT_DIR/backups"
 
 # Test database connection
 echo "Testing database connection..."

--- a/scripts/setup_samba.sh
+++ b/scripts/setup_samba.sh
@@ -9,12 +9,15 @@
 # Exit on error
 set -e
 
+# Determine project directory
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
 # Log file
-LOG_FILE="/home/tim/RFID3/logs/samba_setup.log"
-mkdir -p /home/tim/RFID3/logs
-touch $LOG_FILE
-chown tim:tim $LOG_FILE
-chmod 640 $LOG_FILE
+LOG_FILE="$PROJECT_DIR/logs/samba_setup.log"
+mkdir -p "$PROJECT_DIR/logs"
+touch "$LOG_FILE"
+chown tim:tim "$LOG_FILE"
+chmod 640 "$LOG_FILE"
 exec 1>>$LOG_FILE 2>&1
 echo "$(date '+%Y-%m-%d %H:%M:%S') - Starting Samba setup"
 
@@ -28,11 +31,11 @@ else
 fi
 
 # Create shared directory
-SHARED_DIR="/home/tim/RFID3/shared"
+SHARED_DIR="$PROJECT_DIR/shared"
 echo "Creating shared directory: $SHARED_DIR"
-mkdir -p $SHARED_DIR
-chown tim:tim $SHARED_DIR
-chmod 770 $SHARED_DIR
+mkdir -p "$SHARED_DIR"
+chown tim:tim "$SHARED_DIR"
+chmod 770 "$SHARED_DIR"
 
 # Verify Samba configuration includes RFIDShare
 if ! grep -q "\[RFIDShare\]" /etc/samba/smb.conf; then
@@ -45,7 +48,7 @@ if ! grep -q "\[RFIDShare\]" /etc/samba/smb.conf; then
     # Append RFIDShare configuration
     cat << EOF >> /etc/samba/smb.conf
 [RFIDShare]
-path = /home/tim/RFID3/shared
+path = $PROJECT_DIR/shared
 writable = yes
 browsable = yes
 guest ok = no
@@ -84,7 +87,7 @@ testparm -s
 
 # Set ownership and permissions for log directory
 echo "Setting log directory permissions"
-chown -R tim:tim /home/tim/RFID3/logs
-chmod -R 750 /home/tim/RFID3/logs
+chown -R tim:tim "$PROJECT_DIR/logs"
+chmod -R 750 "$PROJECT_DIR/logs"
 
 echo "$(date '+%Y-%m-%d %H:%M:%S') - Samba setup completed successfully"

--- a/scripts/setup_snapshot_cron.sh
+++ b/scripts/setup_snapshot_cron.sh
@@ -4,12 +4,15 @@
 
 echo "Setting up automated contract snapshots..."
 
+# Determine project directory
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
 # Create necessary directories
-mkdir -p /home/tim/RFID3/logs
+mkdir -p "$PROJECT_DIR/logs"
 
 # Create the cron entry
 CRON_ENTRY="# RFID3 Contract Snapshots - Wed/Fri at 7 AM
-0 7 * * 3,5 cd /home/tim/RFID3 && /home/tim/RFID3/venv/bin/python3 scripts/create_weekly_snapshots.py >> logs/snapshot_cron.log 2>&1"
+0 7 * * 3,5 cd $PROJECT_DIR && $PROJECT_DIR/venv/bin/python3 scripts/create_weekly_snapshots.py >> logs/snapshot_cron.log 2>&1"
 
 # Check if cron entry already exists
 if crontab -l 2>/dev/null | grep -q "create_weekly_snapshots.py"; then
@@ -25,8 +28,8 @@ fi
 # Test the script
 echo ""
 echo "🧪 Testing snapshot script..."
-cd /home/tim/RFID3
-/home/tim/RFID3/venv/bin/python3 scripts/create_weekly_snapshots.py --test 2>&1 | head -10
+cd "$PROJECT_DIR"
+"$PROJECT_DIR/venv/bin/python3" scripts/create_weekly_snapshots.py --test 2>&1 | head -10
 
 echo ""
 echo "📋 Setup complete! Contract snapshots will run:"
@@ -34,9 +37,9 @@ echo "   • Every Wednesday at 7:00 AM"
 echo "   • Every Friday at 7:00 AM"
 echo ""
 echo "📁 Log files:"
-echo "   • /home/tim/RFID3/logs/snapshot_automation.log (detailed logs)"
-echo "   • /home/tim/RFID3/logs/snapshot_cron.log (cron output)"
-echo "   • /home/tim/RFID3/logs/last_snapshot_run.json (status summary)"
+echo "   • $PROJECT_DIR/logs/snapshot_automation.log (detailed logs)"
+echo "   • $PROJECT_DIR/logs/snapshot_cron.log (cron output)"
+echo "   • $PROJECT_DIR/logs/last_snapshot_run.json (status summary)"
 echo ""
-echo "🔧 To check status: cat /home/tim/RFID3/logs/last_snapshot_run.json"
-echo "🔧 To run manually: cd /home/tim/RFID3 && ./scripts/create_weekly_snapshots.py"
+echo "🔧 To check status: cat $PROJECT_DIR/logs/last_snapshot_run.json"
+echo "🔧 To run manually: cd $PROJECT_DIR && ./scripts/create_weekly_snapshots.py"

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-source /home/tim/RFID3/venv/bin/activate
-exec gunicorn --workers 3 --timeout 300 --bind 127.0.0.1:8102 --chdir /home/tim/RFID3 run:app
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$PROJECT_DIR/venv/bin/activate"
+exec gunicorn --workers 3 --timeout 300 --bind 127.0.0.1:8102 --chdir "$PROJECT_DIR" run:app
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -6,10 +6,10 @@ import pytest
 
 # Ensure root directory is on sys.path for config and app imports
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from config import LOGIN_URL
+from config import LOGIN_URL, BASE_DIR
 
 # Ensure log directory exists before importing the client module
-os.makedirs('/home/tim/RFID3/logs', exist_ok=True)
+os.makedirs(os.path.join(BASE_DIR, 'logs'), exist_ok=True)
 
 from app.services.api_client import APIClient
 

--- a/update_from_github.sh
+++ b/update_from_github.sh
@@ -9,7 +9,7 @@
 set -e  # Exit on any error
 
 # Define project directory and log file
-PROJECT_DIR="/home/tim/RFID3"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_FILE="$PROJECT_DIR/logs/update.log"
 
 # Ensure log directory exists


### PR DESCRIPTION
## Summary
- replace hardcoded `/home/tim/RFID3` references with config-based paths
- add PROJECT_DIR variables to scripts and service configs
- centralize log and shared directory paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae18d3efa083259e3c0fc0795dc8de