### PR TITLE
Use Decimal for financial computations

### DIFF
--- a/app/routes/inventory_analytics.py
+++ b/app/routes/inventory_analytics.py
@@ -20,7 +20,7 @@ from sqlalchemy import func, desc, and_, or_, text
 from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime, timedelta
 import json
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 
 logger = get_logger(__name__)
 
@@ -285,9 +285,9 @@ def get_business_intelligence():
             if all_prices:
                 all_prices.sort()
                 percentile_index = int(0.9 * len(all_prices))
-                price_percentile = float(
-                    all_prices[min(percentile_index, len(all_prices) - 1)]
-                )
+                price_percentile = Decimal(
+                    str(all_prices[min(percentile_index, len(all_prices) - 1)])
+                ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
                 high_value_items = base_query.filter(
                     ItemMaster.sell_price >= price_percentile
@@ -302,7 +302,7 @@ def get_business_intelligence():
         # Convert Decimal objects to float for JSON serialization
         def decimal_to_float(value):
             if isinstance(value, Decimal):
-                return float(value)
+                return float(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
             return value
 
         # Build response


### PR DESCRIPTION
## Summary
- Replace float-based payroll and revenue ratios with `Decimal` calculations and two-decimal quantization
- Quantize numeric parsing utilities and growth calculations using `Decimal`
- Apply `Decimal` rounding in inventory analytics price percentile and serialization helpers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp'; ImportError: cannot import name 'StorePerformance')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e43e2b948325955b9bfb2fe7e0b7