### PR TITLE
Add indexes for transaction table

### DIFF
--- a/app/models/db_models.py
+++ b/app/models/db_models.py
@@ -72,6 +72,11 @@ class ItemMaster(db.Model):
 
 class Transaction(db.Model):
     __tablename__ = "id_transactions"
+    __table_args__ = (
+        db.Index("ix_transactions_tag_id", "tag_id"),
+        db.Index("ix_transactions_scan_date", "scan_date"),
+        db.Index("ix_transactions_status", "status"),
+    )
 
     id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
     contract_number = db.Column(db.String(255))

--- a/migrations/202409081200_add_transaction_indexes.py
+++ b/migrations/202409081200_add_transaction_indexes.py
@@ -1,0 +1,37 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def table_exists(cur, name: str) -> bool:
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,))
+    return cur.fetchone() is not None
+
+
+def create_indexes(db_path: str):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    if table_exists(cur, "id_transactions"):
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_transactions_tag_id ON id_transactions (tag_id)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_transactions_scan_date ON id_transactions (scan_date)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS ix_transactions_status ON id_transactions (status)"
+        )
+    else:
+        print("Skipping Transaction indexes; table id_transactions not found")
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    db_file = sys.argv[1] if len(sys.argv) > 1 else "rfid_inventory.db"
+    if not Path(db_file).exists():
+        print(f"Database '{db_file}' does not exist; creating empty file")
+    create_indexes(db_file)
+

--- a/migrations/202409081200_add_transaction_indexes.sql
+++ b/migrations/202409081200_add_transaction_indexes.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS ix_transactions_tag_id ON id_transactions (tag_id);
+CREATE INDEX IF NOT EXISTS ix_transactions_scan_date ON id_transactions (scan_date);
+CREATE INDEX IF NOT EXISTS ix_transactions_status ON id_transactions (status);
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy indexes for `tag_id`, `scan_date`, and `status` on transactions
- create migration scripts to add transaction indexes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp'; ImportError: cannot import name 'StorePerformance')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e61107a08325bd26ab9f5d6654f0