### PR TITLE
Centralize date range logic and add custom range tests

### DIFF
--- a/app/routes/tab7_enhanced.py
+++ b/app/routes/tab7_enhanced.py
@@ -13,47 +13,12 @@ import json
 from decimal import Decimal
 import calendar
 
+from ..utils.date_ranges import get_date_range_from_params
+
 logger = get_logger(__name__)
 
 # Import centralized store configuration
 from ..config.stores import STORE_MAPPING, get_store_name
-
-
-def get_date_range_from_params(request):
-    """Extract and validate date range from request parameters."""
-    # Check for custom date range
-    start_date_str = request.args.get("start_date")
-    end_date_str = request.args.get("end_date")
-
-    if start_date_str and end_date_str:
-        try:
-            start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
-            end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
-            return start_date, end_date
-        except ValueError:
-            logger.error(
-                f"Invalid date format: start={start_date_str}, end={end_date_str}"
-            )
-
-    # Fall back to period-based selection
-    period = request.args.get("period", "4weeks")
-    end_date = datetime.now().date()
-
-    if period == "4weeks":
-        start_date = end_date - timedelta(weeks=4)
-    elif period == "12weeks":
-        start_date = end_date - timedelta(weeks=12)
-    elif period == "52weeks":
-        start_date = end_date - timedelta(weeks=52)
-    elif period == "ytd":
-        start_date = date(end_date.year, 1, 1)
-    elif period == "custom":
-        # Custom period should have dates
-        return None, None
-    else:
-        start_date = end_date - timedelta(weeks=4)
-
-    return start_date, end_date
 
 
 def calculate_comparison_metrics(

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -28,3 +28,9 @@ __all__ = [
     "validate_required_fields",
     "format_error_response",
 ]
+
+from .date_ranges import get_date_range_from_params
+
+__all__ += [
+    "get_date_range_from_params",
+]

--- a/app/utils/date_ranges.py
+++ b/app/utils/date_ranges.py
@@ -1,0 +1,59 @@
+"""Date range utilities for dashboard routes."""
+
+from datetime import datetime, timedelta, date
+from sqlalchemy import func
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_date_range_from_params(request, session=None):
+    """Extract and validate date range from request parameters.
+
+    Supports custom start and end dates via query parameters. If not provided,
+    falls back to a period parameter (4weeks, 12weeks, 52weeks, ytd). When a
+    database session is supplied, the latest available data date is used as the
+    end date instead of today's date.
+    """
+    start_date_str = request.args.get("start_date")
+    end_date_str = request.args.get("end_date")
+
+    if start_date_str and end_date_str:
+        try:
+            start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+            end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+            return start_date, end_date
+        except ValueError:
+            logger.error(
+                "Invalid date format: start=%s, end=%s", start_date_str, end_date_str
+            )
+
+    period = request.args.get("period", "4weeks")
+
+    if session:
+        from app.models.db_models import PayrollTrends
+
+        latest_data_date = (
+            session.query(func.max(PayrollTrends.week_ending))
+            .filter(PayrollTrends.total_revenue > 0)
+            .scalar()
+        )
+        end_date = latest_data_date if latest_data_date else datetime.now().date()
+    else:
+        end_date = datetime.now().date()
+
+    if period == "4weeks":
+        start_date = end_date - timedelta(weeks=4)
+    elif period == "12weeks":
+        start_date = end_date - timedelta(weeks=12)
+    elif period == "52weeks":
+        start_date = end_date - timedelta(weeks=52)
+    elif period == "ytd":
+        start_date = date(end_date.year, 1, 1)
+    elif period == "custom":
+        # Custom period should have dates
+        return None, None
+    else:
+        start_date = end_date - timedelta(weeks=4)
+
+    return start_date, end_date

--- a/tests/test_dashboard_functionality.py
+++ b/tests/test_dashboard_functionality.py
@@ -13,7 +13,7 @@ import pytest
 import json
 import sys
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from decimal import Decimal
 from unittest.mock import Mock, patch, MagicMock
 
@@ -170,6 +170,19 @@ class TestExecutiveDashboard:
         
         calculated_turnover = round(financial_data['revenue']['ytd_total'] / financial_data['inventory']['total_value'], 3)
         assert calculated_turnover == financial_data['inventory']['turnover_ratio']
+
+    def test_custom_date_range_helper(self):
+        """Ensure get_date_range_from_params handles custom ranges."""
+        from app.utils.date_ranges import get_date_range_from_params
+
+        class Req:
+            def __init__(self, args):
+                self.args = args
+
+        req = Req({"start_date": "2025-01-01", "end_date": "2025-01-31"})
+        start, end = get_date_range_from_params(req)
+        assert start == date(2025, 1, 1)
+        assert end == date(2025, 1, 31)
     
     def test_dashboard_chart_data_accuracy(self):
         """Test accuracy of data feeding dashboard charts."""


### PR DESCRIPTION
## Summary
- Move `get_date_range_from_params` into `app/utils/date_ranges.py` for reuse
- Use new date range helper in `tab7` routes to eliminate duplicate logic
- Add unit test covering custom date range handling

## Testing
- `pytest tests/test_dashboard_functionality.py::TestExecutiveDashboard::test_custom_date_range_helper -q`
- `pytest tests/test_dashboard_functionality.py -q` *(fails: assertion mismatches in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b24566d7a88325b7f0366452cbf288