### PR TITLE
refactor: unify global filters

### DIFF
--- a/app/utils/filters.py
+++ b/app/utils/filters.py
@@ -1,4 +1,5 @@
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
+
 from ..models.db_models import ItemMaster
 
 
@@ -13,7 +14,17 @@ def build_global_filters(store_filter="all", type_filter="all"):
             )
         )
     if type_filter and type_filter != "all":
-        filters.append(ItemMaster.identifier_type == type_filter)
+        if type_filter == "RFID":
+            filters.append(
+                and_(
+                    ItemMaster.identifier_type.is_(None),
+                    ItemMaster.tag_id.op("REGEXP")("^[0-9A-Fa-f]{16,}$"),
+                )
+            )
+        elif type_filter == "Serialized":
+            filters.append(ItemMaster.identifier_type.in_(["QR", "Sticker"]))
+        else:
+            filters.append(ItemMaster.identifier_type == type_filter)
     return filters
 
 


### PR DESCRIPTION
## Summary
- centralize advanced store/type filtering in shared utility
- remove shadowed build_global_filters in inventory analytics
- apply unified filters across dashboard and business intelligence routes

## Testing
- `pytest tests/test_global_filters.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b25d9cbd188325af748fc002516be9